### PR TITLE
fix: add missing wf.prepare in main workflow so exports are actually written

### DIFF
--- a/.changeset/fix-empty-linker-ids-append.md
+++ b/.changeset/fix-empty-linker-ids-append.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.clonotype-browser-3.workflow": patch
+---
+
+Fix: `computeClonotypeAnnotations` crashed with "wrong number of arguments in call to builtin-function:append" whenever `linkerIds` was empty — the `append(arr, linkerIds...)` spread collapsed to a single-argument call. Replaced with array concatenation.

--- a/.changeset/fix-main-workflow-missing-prepare.md
+++ b/.changeset/fix-main-workflow-missing-prepare.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.clonotype-browser-3.workflow": patch
+---
+
+Fix: main workflow now emits annotation exports. Added the missing `wf.prepare` step so `args.columnBundle` is populated; without it `getAnnotationAxesSpec` returned `undefined` and the export guard silently skipped writing `annotationsPf` and `filtersPf` to the result pool.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^1.2.3
       version: 1.2.3
     '@platforma-sdk/block-tools':
-      specifier: 2.7.7
-      version: 2.7.7
+      specifier: 2.7.9
+      version: 2.7.9
     '@platforma-sdk/model':
       specifier: 1.64.0
       version: 1.64.0
@@ -88,7 +88,7 @@ importers:
         version: 2.29.5
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.7
+        version: 2.7.9
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -116,7 +116,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.7
+        version: 2.7.9
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -141,7 +141,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.7
+        version: 2.7.9
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -175,7 +175,7 @@ importers:
     devDependencies:
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.64.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.64.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -980,6 +980,9 @@ packages:
   '@milaboratories/pl-model-common@1.31.2':
     resolution: {integrity: sha512-dnK0zXzylN7MAO1Nyx8EJargaqa94iDDEDwZW7d1/lRl1p50cR9zGP8pUnIy1I8UcI4lzH34f81RRQy6AbTuTw==}
 
+  '@milaboratories/pl-model-common@1.32.1':
+    resolution: {integrity: sha512-XFAJw2Re+YZ4rsgIupcNX8MlnsjU0kj53RA1LLBKps/9a5GmNadsN+vXuCaHv7TffGNweyba5gatih0Ek2AbsQ==}
+
   '@milaboratories/pl-model-middle-layer@1.15.0':
     resolution: {integrity: sha512-uYb/H+rYWSY4IckYxKClQF6yLv+yOJMqtIfJusd7MuCn29HYeQLMruowNaf9A/O35bFx5gqAeiF7XDCn2iQHNA==}
 
@@ -988,6 +991,9 @@ packages:
 
   '@milaboratories/pl-model-middle-layer@1.16.4':
     resolution: {integrity: sha512-uFTZHEjRmfRvY97tRbBuTvNzQnTYIj58S8HBzyMsFkzxbUI8vTBPtvEqbTU2IbQ31IEGvv8T0BBl9b7/vdud0A==}
+
+  '@milaboratories/pl-model-middle-layer@1.18.0':
+    resolution: {integrity: sha512-jtCXFydSA6W37a5TvJGe6UL3lrWDN9VwPx2ILqCS2ZBClypm5kqBbPiDs7Xz9zAglL5+K3XOI5opX+HmlB8CzA==}
 
   '@milaboratories/pl-tree@1.9.9':
     resolution: {integrity: sha512-WHeWAR8xAfobdpXBFJY5rBV6lPkpMrfWLiNAROozWp9S16EHFlauHS//ykcxyqwr438HLjkGurDCygbS5COvmQ==}
@@ -1383,6 +1389,10 @@ packages:
 
   '@platforma-sdk/block-tools@2.7.7':
     resolution: {integrity: sha512-pcepxZC9XpSRdKIzb5AarCwvzSqPcr38QJZFo34iQiZF4/fVyFtPLOxT/Lux5eYWGiE82dw0xok4xfO4s7AELA==}
+    hasBin: true
+
+  '@platforma-sdk/block-tools@2.7.9':
+    resolution: {integrity: sha512-QHztFe9Kh7Nq68BofGKUszjkMqIC3Rut873xtJBQT4KMzewZd/+FLnzlok1IOrhPxO+MmpnlMpLT3pgDqIuYUA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -5856,6 +5866,13 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
+  '@milaboratories/pl-model-common@1.32.1':
+    dependencies:
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pl-error-like': 1.12.9
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-middle-layer@1.15.0':
     dependencies:
       '@milaboratories/helpers': 1.14.0
@@ -5876,6 +5893,14 @@ snapshots:
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-model-common': 1.31.2
+      es-toolkit: 1.41.0
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.18.0':
+    dependencies:
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pl-model-common': 1.32.1
       es-toolkit: 1.41.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -6441,6 +6466,27 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@platforma-sdk/block-tools@2.7.9':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.32.1
+      '@milaboratories/pl-model-middle-layer': 1.18.0
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.1
+      '@milaboratories/ts-helpers-oclif': 1.1.40
+      '@oclif/core': 4.2.10
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
+      canonicalize: 2.1.0
+      lru-cache: 11.2.2
+      mime-types: 2.1.35
+      tar: 7.4.3
+      undici: 7.16.0
+      yaml: 2.8.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - aws-crt
+
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     dependencies:
       yaml: 2.8.1
@@ -6490,6 +6536,34 @@ snapshots:
       '@oclif/core': 4.2.10
       winston: 3.17.0
 
+  '@platforma-sdk/test@1.64.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))':
+    dependencies:
+      '@milaboratories/computable': 2.9.2
+      '@milaboratories/pl-client': 3.1.1
+      '@milaboratories/pl-middle-layer': 1.55.8(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-tree': 1.9.9
+      '@platforma-sdk/model': 1.64.0
+      '@vitest/coverage-istanbul': 4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
+      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
+    transitivePeerDependencies:
+      - '@bytecodealliance/preview2-shim'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - aws-crt
+      - bare-buffer
+      - encoding
+      - happy-dom
+      - jsdom
+      - msw
+      - supports-color
+      - vite
+
   '@platforma-sdk/test@1.64.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
     dependencies:
       '@milaboratories/computable': 2.9.2
@@ -6498,7 +6572,7 @@ snapshots:
       '@milaboratories/pl-tree': 1.9.9
       '@platforma-sdk/model': 1.64.0
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
-      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)))(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - '@edge-runtime/vm'
@@ -7342,6 +7416,22 @@ snapshots:
       vite: 8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1)
       vue: 3.5.25(typescript@5.6.3)
 
+  '@vitest/coverage-istanbul@4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@istanbuljs/schema': 0.1.3
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      tinyrainbow: 3.1.0
+      vitest: 2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-istanbul@4.1.4(vitest@4.1.4)':
     dependencies:
       '@babel/core': 7.29.0
@@ -7354,7 +7444,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)))(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -7379,6 +7469,14 @@ snapshots:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)
+
+  '@vitest/mocker@4.1.4(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)
 
@@ -9543,7 +9641,35 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)))(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1)):
+  vitest@4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.5.2
+      '@vitest/coverage-istanbul': 4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   "@platforma-sdk/ui-vue": 1.64.0
   "@platforma-sdk/tengo-builder": 2.5.8
   "@platforma-sdk/package-builder": 3.12.0
-  "@platforma-sdk/block-tools": 2.7.7
+  "@platforma-sdk/block-tools": 2.7.9
 
   "@platforma-sdk/test": 1.64.0
   "@milaboratories/helpers": 1.14.1

--- a/workflow/src/annotations.lib.tengo
+++ b/workflow/src/annotations.lib.tengo
@@ -24,10 +24,7 @@ computeClonotypeAnnotations := func(inputs) {
 
 	ll.assert(len(steps) > 0, "no annotation steps provided")
 
-	additionalColumns := append(
-		[canonical.encode(columns.referenceLabelSelector)],
-		linkerIds...
-	)
+	additionalColumns := [canonical.encode(columns.referenceLabelSelector)] + linkerIds
 
 	result := annotations.computeAnnotations({
 		title: title,

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -6,8 +6,19 @@ pFrames := import("@platforma-sdk/workflow-tengo:pframes")
 
 annotations := import(":annotations")
 annotationsStats := import(":annotations-stats")
+columns := import(":columns")
 
 wf.setPreRun(assets.importTemplate(":prerun"))
+
+wf.prepare(func(args) {
+	result := {}
+	if len(args.annotationSpec.steps) > 0 {
+		bundle := wf.createPBundleBuilder()
+		bundle.addAnchor(columns.mainAnchorName, args.inputAnchor)
+		result.columnBundle = bundle.build()
+	}
+	return result
+})
 
 wf.body(func(args) {
 	outputs := {}


### PR DESCRIPTION
## Summary

The main workflow reads `args.columnBundle` ([workflow/src/main.tpl.tengo:17](workflow/src/main.tpl.tengo#L17)) to derive `annotationAxesSpec`, but nothing ever populates it — only the prerun template had a `wf.prepare` step. Result: `getAnnotationAxesSpec(undefined)` returns `undefined`, the export guard on line 19-21 fails silently, and `exports.annotationsPf` / `exports.filtersPf` are never written to the result pool. Downstream blocks never see the annotation column.

This PR adds the missing `wf.prepare` to `main.tpl.tengo`, mirroring the pattern in `prerun.tpl.tengo` but with a minimal anchor-only bundle (main doesn't need the mainCount/mainFraction selectors that prerun uses for stats).

Also bumps `@platforma-sdk/block-tools` catalog entry from `2.7.7` to `2.7.9` (CI requires latest).

## Why no one caught this sooner

The block's own UI (overlap/stats tables) reads annotations from `ctx.prerun?.resolve(...)` — so the UI worked. Only downstream consumers that query the result pool (e.g. the Antibody/TCR Leads filter discovery) would notice the missing exports.