### PR TITLE
fix: discover linkers in main workflow so cross-axis annotations work

### DIFF
--- a/.changeset/fix-main-workflow-linker-discovery.md
+++ b/.changeset/fix-main-workflow-linker-discovery.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.clonotype-browser-3.workflow": patch
+---
+
+Fix: main workflow now discovers linker columns and passes their IDs to `computeClonotypeAnnotations`. Without this, annotation expressions that reference columns on a different axis (e.g. `clusterId`-keyed enrichment columns bridged from a `clonotypeKey` input) caused the ptabler join to fail with "some of axes sets are disjoint". Prerun already did this; main now mirrors it.

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -7,6 +7,7 @@ pFrames := import("@platforma-sdk/workflow-tengo:pframes")
 annotations := import(":annotations")
 annotationsStats := import(":annotations-stats")
 columns := import(":columns")
+linkers := import(":linkers")
 
 wf.setPreRun(assets.importTemplate(":prerun"))
 
@@ -16,6 +17,7 @@ wf.prepare(func(args) {
 		bundle := wf.createPBundleBuilder()
 		bundle.addAnchor(columns.mainAnchorName, args.inputAnchor)
 		result.columnBundle = bundle.build()
+		result.linkerBundle = linkers.discover(args.inputAnchor)
 	}
 	return result
 })
@@ -26,17 +28,20 @@ wf.body(func(args) {
 
 	annotationSpec := args.annotationSpec
 	annotationAxesSpec := annotationsStats.getAnnotationAxesSpec(args.columnBundle)
+	linkerInfos := is_undefined(args.linkerBundle) ? undefined : linkers.extract(args.linkerBundle)
 
 	if !is_undefined(args.inputAnchor) &&
 		!is_undefined(annotationAxesSpec) &&
 		len(annotationSpec.steps) > 0 {
+		linkerIds := is_undefined(linkerInfos) ? [] : linkers.buildIds(linkerInfos)
 		computedAnnotations := annotations.computeClonotypeAnnotations({
 			title: annotationSpec.title,
 			steps: annotationSpec.steps,
 			inputAnchor: args.inputAnchor,
 			defaultValue: annotationSpec.defaultValue,
 			annotationAxesSpec: annotationAxesSpec,
-			shouldComputeFilters: true
+			shouldComputeFilters: true,
+			linkerIds: linkerIds
 		})
 
 		exports["annotationsPf"] = computedAnnotations.annotationsPf


### PR DESCRIPTION
## Summary

Follow-up to [#22](https://github.com/platforma-open/clonotype-browser/pull/22). With main now actually writing exports, annotation expressions that reference columns on an axis other than the input anchor's (e.g. `clusterId`-keyed `enrichmentQuality` bridged from a `clonotypeKey` input) fail inside ptabler with:

> SpecError::Input error: some of axes sets are disjoint, axes with qualifications: [{clonotypeKey}, {clusterId}]

Prerun avoided this by discovering linker columns via `linkers.discover` / `linkers.extract` / `linkers.buildIds` and passing their canonical IDs through `linkerIds` — the SDK's `computeAnnotations` then adds them to its bundle so the underlying join has a bridge. Main was missing all of this.

This PR adds the same three calls to `main.tpl.tengo`, matching prerun's pattern.