### PR TITLE
feat: expose annotation column as discrete filter for lead selection

### DIFF
--- a/.changeset/annotation-discrete-values.md
+++ b/.changeset/annotation-discrete-values.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.clonotype-browser-3.workflow': patch
+'@platforma-open/milaboratories.clonotype-browser-3': patch
+---
+
+Mark the annotation column as a discrete filter and expose step labels via `pl7.app/discreteValues`. This lets downstream blocks (e.g. TCR/antibody lead selection) render the annotation column as a multi-select dropdown instead of a free-text string filter.

--- a/workflow/src/annotations.lib.tengo
+++ b/workflow/src/annotations.lib.tengo
@@ -1,4 +1,7 @@
+json := import("json")
+
 ll := import("@platforma-sdk/workflow-tengo:ll")
+maps := import("@platforma-sdk/workflow-tengo:maps")
 slices := import("@platforma-sdk/workflow-tengo:slices")
 pFrames := import("@platforma-sdk/workflow-tengo:pframes")
 canonical := import("@platforma-sdk/workflow-tengo:canonical")
@@ -36,9 +39,22 @@ computeClonotypeAnnotations := func(inputs) {
 		shouldComputeFilters: shouldComputeFilters
 	})
 
+	// Expose the annotation column as a discrete filter so downstream blocks
+	// (e.g. TCR/antibody lead selection) render a multi-select dropdown.
+	// The possible values are the step labels.
+	stepLabels := slices.map(steps, func(s) { return s.name })
+	annotationsColumn := maps.deepMerge(result.annotationsColumn, {
+		spec: {
+			annotations: {
+				"pl7.app/isDiscreteFilter": "true",
+				"pl7.app/discreteValues": string(json.encode(stepLabels))
+			}
+		}
+	})
+
 	return {
-		annotationsColumn: result.annotationsColumn,
-		annotationsPf: convertToPFrame(result.annotationsColumn),
+		annotationsColumn: annotationsColumn,
+		annotationsPf: convertToPFrame(annotationsColumn),
 		filtersColumns: result.annotationsFiltersColumns,
 		filtersPf: convertToPFrame(result.annotationsFiltersColumns...)
 	}


### PR DESCRIPTION
## Summary
The exported annotation column (`pl7.app/annotation/result`) was missing the `pl7.app/isDiscreteFilter` and `pl7.app/discreteValues` annotations. Downstream blocks — in particular `antibody-tcr-lead-selection` (`FilterCard.vue::isMultiSelectColumn`) — require both to render a multi-select dropdown for String columns. Without them the annotation column fell through to free-text `contains` / `equals` filtering, which is useless for picking named annotation categories.

This patches the spec after `annotations.computeAnnotations` returns, using `steps[].name` as the discrete value list.