### PR TITLE
chore: update platforma-sdk dependencies to latest patch versions

### DIFF
--- a/.changeset/afraid-friends-lick.md
+++ b/.changeset/afraid-friends-lick.md
@@ -1,0 +1,9 @@
+---
+"@platforma-open/milaboratories.clonotype-browser-3": patch
+"@platforma-open/milaboratories.clonotype-browser-3.model": patch
+"@platforma-open/milaboratories.clonotype-browser-3.test": patch
+"@platforma-open/milaboratories.clonotype-browser-3.ui": patch
+"@platforma-open/milaboratories.clonotype-browser-3.workflow": patch
+---
+
+dont show column header linker postfix

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,17 +31,17 @@ catalogs:
       specifier: 2.7.23
       version: 2.7.23
     '@platforma-sdk/model':
-      specifier: 1.75.2
-      version: 1.75.2
+      specifier: 1.75.5
+      version: 1.75.5
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.25
-      version: 2.5.25
+      specifier: 2.5.26
+      version: 2.5.26
     '@platforma-sdk/test':
-      specifier: 1.75.3
-      version: 1.75.3
+      specifier: 1.75.5
+      version: 1.75.5
     '@platforma-sdk/ui-vue':
-      specifier: 1.75.2
-      version: 1.75.2
+      specifier: 1.75.5
+      version: 1.75.5
     '@platforma-sdk/workflow-tengo':
       specifier: 5.21.0
       version: 5.21.0
@@ -112,7 +112,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.75.2
+        version: 1.75.5
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
@@ -128,7 +128,7 @@ importers:
         version: 1.14.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.75.2
+        version: 1.75.5
       '@types/lodash.omit':
         specifier: ^4.5.9
         version: 4.5.9
@@ -171,14 +171,14 @@ importers:
         version: 2.4.1
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.75.2
+        version: 1.75.5
       this-block:
         specifier: workspace:@platforma-open/milaboratories.clonotype-browser-3@*
         version: link:../block
     devDependencies:
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.75.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.75.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -196,10 +196,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.75.2
+        version: 1.75.5
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.75.2(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.75.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@vueuse/core':
         specifier: 'catalog:'
         version: 13.5.0(vue@3.5.25(typescript@5.6.3))
@@ -252,10 +252,10 @@ importers:
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.25
+        version: 2.5.26
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.75.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.75.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -897,9 +897,6 @@ packages:
     resolution: {integrity: sha512-Dqwj7fLVF+ft7lSMNbzulAH2OtOf5KKaC21tlAXHliO0heMLF2u0lDiCwcHo7/xDNml3gJIWqg4nAGPY7CyPng==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pf-spec-driver@1.3.13':
-    resolution: {integrity: sha512-FjMcDpj8IPbbTfk1Cidp9d12rv+UtTAJ5ZsZc+OUBVKqMxn34XJUTBttrbyD4dBVzN4aBCy2dSehtrNOcjjKyQ==}
-
   '@milaboratories/pf-spec-driver@1.3.14':
     resolution: {integrity: sha512-0l1nW6OHNKjFZg68tyxrIDRADaHtDJac59GatQHkl6EHWpZ0hN1cBDdQ2vn5BGo0jk0ZLPnlCCg0D2MUVCY3sA==}
 
@@ -920,8 +917,8 @@ packages:
       '@milaboratories/pl-model-common': 1.36.0
       '@milaboratories/pl-model-middle-layer': 1.18.5
 
-  '@milaboratories/pl-client@3.3.3':
-    resolution: {integrity: sha512-EBAB09nig9AztPmdupoG1IPIWnYuqUDUzG1NbhFbd3S4FHCGS/kM9mK3t8UL/1WBPdSovrB06izwHc9KVCSiYw==}
+  '@milaboratories/pl-client@3.4.0':
+    resolution: {integrity: sha512-JDZGU3w/Ie6G5hcZfJbqYxV7i9Cl051FOD0blAqYYsoZ5Am/WaPeC0a9SXNoHrVLe/aul5O137kMUa61qQxA9Q==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-config@1.8.1':
@@ -931,8 +928,8 @@ packages:
     resolution: {integrity: sha512-4WfaswDtrI/6M2R/lyAVJX9uOvhQlxNs3EPvCbkPfyqI/3isLhrMSTxHha4w103OQBH8Qc3D3anzyQFWUs7P6w==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.14.3':
-    resolution: {integrity: sha512-fz4EudfwNY0fOZtplZZkhMUC800OH1I+W/LaxGfhUTlgRtEBc0hjoXX2cEzCUYK/BzeaLHdV9aN01Wdhsp+Jlw==}
+  '@milaboratories/pl-drivers@1.14.4':
+    resolution: {integrity: sha512-MbN/jpNeM9C19DcMIWX0kpJWqLfElzQQymLjQRiwBguK+JOvhbQwimRLIRlgwwGZ961kSi+wOokmbNMy5X/Ujg==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
@@ -944,18 +941,18 @@ packages:
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-errors@1.4.3':
-    resolution: {integrity: sha512-GkZgCLOhz8yHRDhgaVoEIQp2lMAwhZ8xIdsqKmRu8pAOAesJkFei5osDZ2I8mM6AxpqfOZtOy6PNSCL8WAYLyg==}
+  '@milaboratories/pl-errors@1.4.4':
+    resolution: {integrity: sha512-VRW3LAETHBRqlpAPPpLxzktOSGdSbx6Qeuf8sNy3I5mOav8kQzyLfPrOSI3QhfE2bs2H60ioElAnkNEbDl1xow==}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.59.4':
-    resolution: {integrity: sha512-NXCJIuA61SpjqPK74Al9BIsqhQH6GxiCgo/eNphgwj9WZDSp8BOyR4LlIaqPcS5I3NCQP0UVFAuJRqrj1BjXBQ==}
+  '@milaboratories/pl-middle-layer@1.59.6':
+    resolution: {integrity: sha512-5uK5FVG9dIyCwDCb48vOxisxxfXqqxa/vyy1xse4kC86BQh9R/V9GAzVqLk+aEq9c3ySfqxFAp4NTt3v4m5Cmg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.2.25':
-    resolution: {integrity: sha512-zKyj3P5/rnJJLn0yijWNdJ3WnWUF6p6+sEzgTfW6uaZH5b+10Yl9WCqWVtf2mCqiS9U5j1eJ9IVG8RJveR0F5A==}
+  '@milaboratories/pl-model-backend@1.2.26':
+    resolution: {integrity: sha512-ZUdzx3c9NLsepYRIfUev5H8B6ynawFuug1ukxL/bMMaArUncjwDE2XdRYFbCACIz4vxAZAp0p+zBXxAcC5VA/g==}
 
   '@milaboratories/pl-model-common@1.21.9':
     resolution: {integrity: sha512-0n8oq0e4ZqbMJIzVnP478BGT86vB4gNSRoDic1ai7bNwMiO+jtNSOwGMwR0mFeRLqXidSLcfDxiEMXmak34f7g==}
@@ -963,30 +960,21 @@ packages:
   '@milaboratories/pl-model-common@1.36.0':
     resolution: {integrity: sha512-BbFs3sTmy12ZKfTY6rFep0C5pfQoLvsjACN8EYaNIjXqOjQajt6velh4uGpB47+Uyp78k0cIWH4T04MIlixQrw==}
 
-  '@milaboratories/pl-model-common@1.41.1':
-    resolution: {integrity: sha512-F/yvmdrbzr0xxEpiZMmN1Q1Q50arw9OLvDLxypTqtsGzwnEAm4OzLLxXIhycu+g8UGvOgOvA5smLiBWu4PhjKA==}
-
   '@milaboratories/pl-model-common@1.41.2':
     resolution: {integrity: sha512-gp4P0+MNF+u1DcbO+clIbRy4bIHkZrixsQ4rOEE0ln8gWdWy6tN25MdbrWYaobYOWh8TupeH+rzCOSRbK5ubQg==}
 
   '@milaboratories/pl-model-middle-layer@1.18.5':
     resolution: {integrity: sha512-eIYE77rBva0k2KWDUmKJBHnGcyi/Tnc5rhlwZVb8q3hS3L4Upf4Pk7/lBL4ZLxYVMZ3/Da0Wp3EKYspUagi9Zg==}
 
-  '@milaboratories/pl-model-middle-layer@1.19.2':
-    resolution: {integrity: sha512-FJxEkrxnRTMjxYF6kLgsgCQKQM6k+LfFjg97RBAeS3KIi1ToRHkWqLMR9kOdmMtTzJWD3iXFAs3mKzNTKhnnlA==}
-
   '@milaboratories/pl-model-middle-layer@1.19.3':
     resolution: {integrity: sha512-MurcKSqJSPsc3uAUaK5o4STDY+Nvl1prd1aF1UlMWsxLKn3pXd+Aoa3I1W8q3jraQRHSfE3efNPWD0/uJueMPw==}
 
-  '@milaboratories/pl-tree@1.10.3':
-    resolution: {integrity: sha512-I4ARePN2sc3EZlJ5Guxt857lPsGxSQPVJSd/kKXNpclhIlSgfAb9a6v9DVI9MNRubOzmBWtLKh+tKEkqRCY6nw==}
+  '@milaboratories/pl-tree@1.10.4':
+    resolution: {integrity: sha512-2KnCP7gT65SM0ClzW9AIy2EYA83d07175boiRJBg2jUMZzzmcr9GbyeONLvVsOJkLfL9uFNokTs6WcKcDx/60w==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/ptabler-expression-js@1.1.5':
     resolution: {integrity: sha512-EBnOKHbXNhR+dGeKvUY84eEdXgZeLrunJdlNpauXWa+mnaCOwF2J1xxjberfeAi36xS90IoeW6Hy7pi9k0TycQ==}
-
-  '@milaboratories/ptabler-expression-js@1.2.23':
-    resolution: {integrity: sha512-czd4sIlaxAzlbdoXw81UIHkuXn7JI4ZUoI/gOHhjqhbE2Txz1xeAnySnSJy1J+wiwUB29VcZqDLoU93gN190yQ==}
 
   '@milaboratories/ptabler-expression-js@1.2.24':
     resolution: {integrity: sha512-zh36PeUwenktXZL6RmqYavnDPReP6bd9J8if4pxMBMUELSllYLSdzyY4InKfjQBaIjYuFaDPYQfAiHcyJFlhSw==}
@@ -1016,11 +1004,11 @@ packages:
     resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.14.2':
-    resolution: {integrity: sha512-EvfyxPyxDs/YQvYoyd5LvJtVirQ1mjza0N0mkmYpC8UyPIZWmh0x5qKBlLyD/QfIHMhDQd7UB7McmYolUGe9Qw==}
-
   '@milaboratories/uikit@2.14.3':
     resolution: {integrity: sha512-neRnO3kR1HTW7ceXof03LBSCoxxXDCbebi32w+4hlwAiNDxE5y5ah+BPMviRmIUf+L1MFh1F0cf4lU9sGrQQzw==}
+
+  '@milaboratories/uikit@2.14.4':
+    resolution: {integrity: sha512-ayBoicuU7lfhv0x2tz6+RFk61uSvw/+ILm+7RjvYBq66LCc+5XH/ns10JziPyL3o/AIKUlJ07rqkA2p67oMuoA==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1289,9 +1277,6 @@ packages:
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.5':
     resolution: {integrity: sha512-8KDVwfi00gqNU8r92XxecVleu/Jk5RoylwOMsoUatbkyTVL/+yQavdAgXc5aRLop07AvG3cFpHXW8ZqYBc7zbQ==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.7':
-    resolution: {integrity: sha512-yeaOLqDjM+ySV3jiyqlF+OoH4ExlDS00tKmYASe7uB6m0z5bg3bcX399odaANgTOopRmG+RE1k9fkgrhLT6R9A==}
-
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.8':
     resolution: {integrity: sha512-OT316tXG5FvN4NPyUaExfVipu4PWEnQxC5ZoKy4zsnT5Ivx+jQF9nzX8JAQsbXCQDUJU8NsL+I2CBcyjxOPJTA==}
 
@@ -1372,25 +1357,25 @@ packages:
   '@platforma-sdk/model@1.46.0':
     resolution: {integrity: sha512-tY1kad46WKvpGHSPoOXfQ3FuBs62CL7rQLrBlzEhfQRAL96dWbycORbH1oo82vEzW39f7F6Q5kgg14Yx6uL/tQ==}
 
-  '@platforma-sdk/model@1.75.1':
-    resolution: {integrity: sha512-pOCLWjSMR6rNMOtMRI5IMQ1d+e7PM2L6LwDeJoJMdGezpGqgarAbS0RDLgCGb7FjK2Qt5vN7xBM1ibMHDGXhIw==}
-
   '@platforma-sdk/model@1.75.2':
     resolution: {integrity: sha512-8Jh0PXNAJg479t7sS6ZVv+wY3bNbVhEZD2zbFqlFd+KSP0Ue0xjZtP9ajCzBuJ/ZCoWm36Cf6rCX0vuAFmPmcw==}
 
-  '@platforma-sdk/tengo-builder@2.5.25':
-    resolution: {integrity: sha512-ojcWNxL4mniBPajVdE4abAgUcEwk5x2C5UuqF0S369KRzXrOX5WkBDzg9ELKFH77b2YwJYmAxy/pf2WdHT2ACw==}
+  '@platforma-sdk/model@1.75.5':
+    resolution: {integrity: sha512-ANEHRR+JlZyYRGltFaP1Gr47ppwEesnEDJ4Xikb45/isFGD8QrjxdmP5uZn+mrFY47ZFltUvqKPB2UASXvr2gQ==}
+
+  '@platforma-sdk/tengo-builder@2.5.26':
+    resolution: {integrity: sha512-GTONZEz5aFuX/bcT17j08aAl6txBWtLB/cNDUJ+V+57E/vPtP1q96jJQJNDyiP94jpyBGeViDfh+zSUJ3qwYsg==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.75.3':
-    resolution: {integrity: sha512-pXTffO1JAOemLoO0bkToT9gGVO8dSOiqk3mOeQLgtLBklIh0FUormHJ/n1GXL5SM46rKDeEokmut2YD1kMD7YA==}
-
-  '@platforma-sdk/ui-vue@1.75.1':
-    resolution: {integrity: sha512-56P86LhfugqHXZiWPSn6ALejzd+nSSxT2sQ9eZrVAfs6e5k03pVSa6nraRD5/HGIJE/O+EVncmDjYEd2/m9n7w==}
+  '@platforma-sdk/test@1.75.5':
+    resolution: {integrity: sha512-l3Vy+2FxrjqtvWRVBULAsTLRWTWGhMs+Z79f9JI8nJ++j1ek72bsWF2LXPpo69uKGy6colP7GHDnOye3d4sM9w==}
 
   '@platforma-sdk/ui-vue@1.75.2':
     resolution: {integrity: sha512-RWUirbaIoTyIiZxxL2gNI/aQ2jXtQQktMktI+UFGILONIJ9EAa2Hq7d5mYFA1MXGY2YdCnjUFs5W/9KkzmlLDg==}
+
+  '@platforma-sdk/ui-vue@1.75.5':
+    resolution: {integrity: sha512-U4h0+tW5TEB4tAYRIHn/fRDUJDDxwPsQDQbGt1k0tqCzE4cmlz0j0XzFk0rxf6wk/n65nBzbefSW7kOR7frPuw==}
 
   '@platforma-sdk/workflow-tengo@5.20.1':
     resolution: {integrity: sha512-CltEAQR0rQVpEaufge9ok8PqpkG+STrYNEmZOApk4E66tL4bwt/0rlEkhQ4njplcqEMcFRXJvW7QdrgyxziuuA==}
@@ -5508,16 +5493,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-spec-driver@1.3.13(@bytecodealliance/preview2-shim@0.17.8)':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.41.1)(@milaboratories/pl-model-middle-layer@1.19.2)
-      '@milaboratories/pl-model-common': 1.41.1
-      '@milaboratories/pl-model-middle-layer': 1.19.2
-      '@noble/hashes': 2.0.1
-    transitivePeerDependencies:
-      - '@bytecodealliance/preview2-shim'
-
   '@milaboratories/pf-spec-driver@1.3.14(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -5549,13 +5524,6 @@ snapshots:
 
   '@milaboratories/pframes-rs-wasi@1.1.31': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.41.1)(@milaboratories/pl-model-middle-layer@1.19.2)':
-    dependencies:
-      '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasi': 1.1.31
-      '@milaboratories/pl-model-common': 1.41.1
-      '@milaboratories/pl-model-middle-layer': 1.19.2
-
   '@milaboratories/pframes-rs-wasm@1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.41.2)(@milaboratories/pl-model-middle-layer@1.19.3)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
@@ -5563,7 +5531,7 @@ snapshots:
       '@milaboratories/pl-model-common': 1.41.2
       '@milaboratories/pl-model-middle-layer': 1.19.3
 
-  '@milaboratories/pl-client@3.3.3':
+  '@milaboratories/pl-client@3.4.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
@@ -5601,14 +5569,14 @@ snapshots:
       yaml: 2.8.1
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.14.3':
+  '@milaboratories/pl-drivers@1.14.4':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/computable': 2.9.4
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-client': 3.3.3
+      '@milaboratories/pl-client': 3.4.0
       '@milaboratories/pl-model-common': 1.41.2
-      '@milaboratories/pl-tree': 1.10.3
+      '@milaboratories/pl-tree': 1.10.4
       '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
@@ -5640,9 +5608,9 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-errors@1.4.3':
+  '@milaboratories/pl-errors@1.4.4':
     dependencies:
-      '@milaboratories/pl-client': 3.3.3
+      '@milaboratories/pl-client': 3.4.0
       '@milaboratories/ts-helpers': 1.8.2
       zod: 3.25.76
 
@@ -5650,7 +5618,7 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.59.4(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pl-middle-layer@1.59.6(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/computable': 2.9.4
       '@milaboratories/helpers': 1.14.2
@@ -5658,19 +5626,19 @@ snapshots:
       '@milaboratories/pf-spec-driver': 1.3.14(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pframes-rs-node': 1.1.31
       '@milaboratories/pframes-rs-wasm': 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.41.2)(@milaboratories/pl-model-middle-layer@1.19.3)
-      '@milaboratories/pl-client': 3.3.3
+      '@milaboratories/pl-client': 3.4.0
       '@milaboratories/pl-deployments': 2.17.16
-      '@milaboratories/pl-drivers': 1.14.3
-      '@milaboratories/pl-errors': 1.4.3
+      '@milaboratories/pl-drivers': 1.14.4
+      '@milaboratories/pl-errors': 1.4.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.2.25
+      '@milaboratories/pl-model-backend': 1.2.26
       '@milaboratories/pl-model-common': 1.41.2
       '@milaboratories/pl-model-middle-layer': 1.19.3
-      '@milaboratories/pl-tree': 1.10.3
+      '@milaboratories/pl-tree': 1.10.4
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
       '@platforma-sdk/block-tools': 2.7.23
-      '@platforma-sdk/model': 1.75.2
+      '@platforma-sdk/model': 1.75.5
       '@platforma-sdk/workflow-tengo': 5.21.0
       canonicalize: 2.1.0
       denque: 2.1.0
@@ -5688,9 +5656,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.2.25':
+  '@milaboratories/pl-model-backend@1.2.26':
     dependencies:
-      '@milaboratories/pl-client': 3.3.3
+      '@milaboratories/pl-client': 3.4.0
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -5704,13 +5672,6 @@ snapshots:
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-error-like': 1.12.9
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-common@1.41.1':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -5729,14 +5690,6 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.19.2':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.41.1
-      es-toolkit: 1.41.0
-      utility-types: 3.11.0
-      zod: 3.25.76
-
   '@milaboratories/pl-model-middle-layer@1.19.3':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -5745,11 +5698,11 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.10.3':
+  '@milaboratories/pl-tree@1.10.4':
     dependencies:
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/pl-client': 3.3.3
-      '@milaboratories/pl-errors': 1.4.3
+      '@milaboratories/pl-client': 3.4.0
+      '@milaboratories/pl-errors': 1.4.4
       '@milaboratories/ts-helpers': 1.8.2
       denque: 2.1.0
       utility-types: 3.11.0
@@ -5758,10 +5711,6 @@ snapshots:
   '@milaboratories/ptabler-expression-js@1.1.5':
     dependencies:
       '@platforma-open/milaboratories.software-ptabler.schema': 1.12.5
-
-  '@milaboratories/ptabler-expression-js@1.2.23':
-    dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.7
 
   '@milaboratories/ptabler-expression-js@1.2.24':
     dependencies:
@@ -5826,10 +5775,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.14.2(typescript@5.6.3)':
+  '@milaboratories/uikit@2.14.3(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.75.1
+      '@platforma-sdk/model': 1.75.2
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -5860,10 +5809,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@milaboratories/uikit@2.14.3(typescript@5.6.3)':
+  '@milaboratories/uikit@2.14.4(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.75.2
+      '@platforma-sdk/model': 1.75.5
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -6118,15 +6067,15 @@ snapshots:
 
   '@platforma-open/milaboratories.mixcr-clonotyping-2.model@1.20.0':
     dependencies:
-      '@platforma-sdk/model': 1.75.2
+      '@platforma-sdk/model': 1.75.5
       zod: 3.23.8
 
   '@platforma-open/milaboratories.mixcr-clonotyping-2.ui@1.19.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model': 1.20.0
-      '@platforma-sdk/model': 1.75.2
-      '@platforma-sdk/ui-vue': 1.75.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@platforma-sdk/model': 1.75.5
+      '@platforma-sdk/ui-vue': 1.75.2(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@vueuse/core': 13.9.0(vue@3.5.25(typescript@5.6.3))
       ag-grid-enterprise: 34.1.2
       ag-grid-vue3: 34.1.2(vue@3.5.25(typescript@5.6.3))
@@ -6158,7 +6107,7 @@ snapshots:
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model': 1.20.0
       '@platforma-open/milaboratories.mixcr-clonotyping-2.ui': 1.19.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@platforma-open/milaboratories.mixcr-clonotyping-2.workflow': 3.17.1
-      '@platforma-sdk/model': 1.75.2
+      '@platforma-sdk/model': 1.75.5
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - async-validator
@@ -6205,10 +6154,6 @@ snapshots:
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.5':
     dependencies:
       '@milaboratories/pl-model-common': 1.21.9
-
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.7':
-    dependencies:
-      '@milaboratories/pl-model-common': 1.41.1
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.8':
     dependencies:
@@ -6311,19 +6256,6 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@platforma-sdk/model@1.75.1':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.41.1
-      '@milaboratories/pl-model-middle-layer': 1.19.2
-      '@milaboratories/ptabler-expression-js': 1.2.23
-      canonicalize: 2.1.0
-      es-toolkit: 1.41.0
-      fast-json-patch: 3.1.1
-      utility-types: 3.11.0
-      zod: 3.25.76
-
   '@platforma-sdk/model@1.75.2':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -6337,24 +6269,37 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@platforma-sdk/tengo-builder@2.5.25':
+  '@platforma-sdk/model@1.75.5':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.25
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-error-like': 1.12.10
+      '@milaboratories/pl-model-common': 1.41.2
+      '@milaboratories/pl-model-middle-layer': 1.19.3
+      '@milaboratories/ptabler-expression-js': 1.2.24
+      canonicalize: 2.1.0
+      es-toolkit: 1.41.0
+      fast-json-patch: 3.1.1
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@platforma-sdk/tengo-builder@2.5.26':
+    dependencies:
+      '@milaboratories/pl-model-backend': 1.2.26
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.2.10
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.75.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.75.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))':
     dependencies:
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/pl-client': 3.3.3
-      '@milaboratories/pl-middle-layer': 1.59.4(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-tree': 1.10.3
-      '@platforma-sdk/model': 1.75.2
-      '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
-      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)))(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+      '@milaboratories/pl-client': 3.4.0
+      '@milaboratories/pl-middle-layer': 1.59.6(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-tree': 1.10.4
+      '@platforma-sdk/model': 1.75.5
+      '@vitest/coverage-istanbul': 4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
+      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - '@edge-runtime/vm'
@@ -6374,12 +6319,40 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.75.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/test@1.75.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.3.13(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.41.1
-      '@milaboratories/uikit': 2.14.2(typescript@5.6.3)
-      '@platforma-sdk/model': 1.75.1
+      '@milaboratories/computable': 2.9.4
+      '@milaboratories/pl-client': 3.4.0
+      '@milaboratories/pl-middle-layer': 1.59.6(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-tree': 1.10.4
+      '@platforma-sdk/model': 1.75.5
+      '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
+      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+    transitivePeerDependencies:
+      - '@bytecodealliance/preview2-shim'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - aws-crt
+      - bare-buffer
+      - encoding
+      - happy-dom
+      - jsdom
+      - msw
+      - supports-color
+      - vite
+
+  '@platforma-sdk/ui-vue@1.75.2(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+    dependencies:
+      '@milaboratories/pf-spec-driver': 1.3.14(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.41.2
+      '@milaboratories/uikit': 2.14.3(typescript@5.6.3)
+      '@platforma-sdk/model': 1.75.2
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -6410,12 +6383,12 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/ui-vue@1.75.2(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.75.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/pf-spec-driver': 1.3.14(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.41.2
-      '@milaboratories/uikit': 2.14.3(typescript@5.6.3)
-      '@platforma-sdk/model': 1.75.2
+      '@milaboratories/uikit': 2.14.4(typescript@5.6.3)
+      '@platforma-sdk/model': 1.75.5
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -7149,6 +7122,22 @@ snapshots:
       vite: 8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1)
       vue: 3.5.25(typescript@5.6.3)
 
+  '@vitest/coverage-istanbul@4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@istanbuljs/schema': 0.1.3
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      tinyrainbow: 3.1.0
+      vitest: 2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-istanbul@4.1.4(vitest@4.1.4)':
     dependencies:
       '@babel/core': 7.29.0
@@ -7161,7 +7150,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)))(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+      vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -7186,6 +7175,14 @@ snapshots:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)
+
+  '@vitest/mocker@4.1.4(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)
 
@@ -9317,7 +9314,35 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)))(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1)):
+  vitest@4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 5.4.14(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.5.2
+      '@vitest/coverage-istanbul': 4.1.4(vitest@2.1.9(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.2))
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,13 +11,13 @@ catalog:
   "@milaboratories/build-configs": 2.0.0
   "@milaboratories/pl-model-common": 1.41.2
   "@platforma-sdk/workflow-tengo": 5.21.0
-  "@platforma-sdk/model": 1.75.2
-  "@platforma-sdk/ui-vue": 1.75.2
-  "@platforma-sdk/tengo-builder": 2.5.25
+  "@platforma-sdk/model": 1.75.5
+  "@platforma-sdk/ui-vue": 1.75.5
+  "@platforma-sdk/tengo-builder": 2.5.26
   "@platforma-sdk/package-builder": 3.12.0
   "@platforma-sdk/block-tools": 2.7.23
 
-  "@platforma-sdk/test": 1.75.3
+  "@platforma-sdk/test": 1.75.5
   "@milaboratories/helpers": 1.14.2
 
   "@platforma-open/milaboratories.runenv-python-3": ^1.7.7


### PR DESCRIPTION
- Updated @platforma-sdk/model from 1.75.2 to 1.75.5
- Updated @platforma-sdk/ui-vue from 1.75.2 to 1.75.5
- Updated @platforma-sdk/tengo-builder from 2.5.25 to 2.5.26
- Updated @platforma-sdk/test from 1.75.3 to 1.75.5

feat: add changeset for clonotype-browser-3 patches

- Added changeset for patch updates to clonotype-browser-3 and its related packages
- Fixed issue where column header linker postfix was displayed