### PR TITLE
Migration to new column access

### DIFF
--- a/.changeset/pink-wings-dream.md
+++ b/.changeset/pink-wings-dream.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.clonotype-browser-3.model": patch
+"@platforma-open/milaboratories.clonotype-browser-3.ui": patch
+"@platforma-open/milaboratories.clonotype-browser-3": patch
+---
+
+Migration to the new SDK versions

--- a/.changeset/pink-wings-dream.md
+++ b/.changeset/pink-wings-dream.md
@@ -4,4 +4,4 @@
 "@platforma-open/milaboratories.clonotype-browser-3": patch
 ---
 
-Migration to the new SDK versions
+Migration to the new SDK versions. Restore the released annotation filter behavior: per-sample abundance columns are offered as single entries without a sample picker or per-sample split.

--- a/model/src/dataModel.ts
+++ b/model/src/dataModel.ts
@@ -1,17 +1,42 @@
 import {
+  createGlobalPObjectId,
   createPlDataTableStateV2,
   DataModelBuilder,
+  type ColumnUniversalId,
   type PlDataTableStateV2,
+  type PlRef,
 } from "@platforma-sdk/model";
-import type { BlockData, LegacyBlockArgs, LegacyUiState } from "./types";
+import type { AnnotationSpecUi, BlockData, LegacyBlockArgs, LegacyUiState } from "./types";
 
-/** V1 schema: sampleTableState could be absent for early Ver_2026_04_07 data. */
-type BlockDataV1 = Omit<BlockData, "sampleTableState"> & {
+/**
+ * Stored shape at Ver_2026_04_07. `inputAnchor` was a `PlRef` and
+ * `sampleTableState` could be absent for early data of this version.
+ */
+type StoredV1 = {
+  inputAnchor?: PlRef;
+  settingsOpen: boolean;
+  overlapTableState: PlDataTableStateV2;
   sampleTableState?: PlDataTableStateV2;
+  statsTableState: PlDataTableStateV2;
+  annotationSpecUi: AnnotationSpecUi;
 };
 
+/** Stored shape at Ver_2026_04_14: same as V1 but `sampleTableState` is required. */
+type StoredV2 = Omit<StoredV1, "sampleTableState"> & {
+  sampleTableState: PlDataTableStateV2;
+};
+
+/**
+ * Legacy `inputAnchor` was a `PlRef`. The new `BlockData` carries a
+ * `ColumnUniversalId` (canonical stringified id). For result-pool leaves the
+ * conversion is `createGlobalPObjectId` of the ref's `(blockId, name)`.
+ */
+function plRefToUniversalId(ref: PlRef | undefined): ColumnUniversalId | undefined {
+  return ref ? createGlobalPObjectId(ref.blockId, ref.name) : undefined;
+}
+
 export const blockDataModel = new DataModelBuilder()
-  .from<BlockDataV1>("Ver_2026_04_07")
+  .from<StoredV1>("Ver_2026_04_07")
   .upgradeLegacy<LegacyBlockArgs, LegacyUiState>(({ args, uiState }) => ({
     inputAnchor: args.inputAnchor,
     settingsOpen: uiState?.settingsOpen ?? true,
@@ -20,9 +45,13 @@ export const blockDataModel = new DataModelBuilder()
     statsTableState: uiState?.statsTable?.tableState ?? createPlDataTableStateV2(),
     annotationSpecUi: uiState?.annotationSpec ?? { title: "", steps: [] },
   }))
-  .migrate<BlockData>("Ver_2026_04_14", (prev) => ({
+  .migrate<StoredV2>("Ver_2026_04_14", (prev) => ({
     ...prev,
     sampleTableState: prev.sampleTableState ?? createPlDataTableStateV2(),
+  }))
+  .migrate<BlockData>("Ver_2026_05_28", (prev) => ({
+    ...prev,
+    inputAnchor: plRefToUniversalId(prev.inputAnchor),
   }))
   .init(() => ({
     settingsOpen: true,

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -173,7 +173,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     if (ctx.data.inputAnchor === undefined) return undefined;
     return createPlDataTableV3(ctx, {
       columns: {
-        anchors: { main: ctx.data.inputAnchor as unknown as PObjectId },
+        anchors: { main: ctx.data.inputAnchor as PObjectId },
         selector: {
           mode: "enrichment",
           exclude: [

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,47 +1,39 @@
 import type {
   AxesSpec,
-  ColumnSnapshot,
-  ColumnVariant,
-  DiscoveredPColumnId,
+  ColumnRecipe,
+  ColumnUniversalId,
   InferOutputsType,
-  PColumn,
-  PColumnDataUniversal,
   PColumnSpec,
   PlRef,
   PObjectId,
-  SUniversalPColumnId,
+  RelaxedColumnSelector,
 } from "@platforma-sdk/model";
 import {
   BlockModelV3,
-  collectCtxColumnSnapshotProviders,
-  ColumnCollectionBuilder,
+  Column,
+  ColumnsCollection,
   convertFilterSpecsToExpressionSpecs,
-  createDiscoveredPColumnId,
   createPlDataTableSheet,
   createPlDataTableV3,
+  deriveAxisValuesLabels,
   deriveDistinctLabels,
   expandByPartition,
+  deriveColumnOptions,
+  getLeafColumnData,
   getUniquePartitionKeys,
-  OutputColumnProvider,
-  plRefsEqual,
-  type RenderCtxBase,
+  isLeafColumn,
+  isPlRef,
+  TreeNodeAccessor,
+  parseJsonSafely,
 } from "@platforma-sdk/model";
-import {
-  Annotation,
-  getTrace,
-  isAbundanceColumn,
-  isSampleCountColumn,
-  PAxisName,
-  PColumnName,
-  readAnnotation,
-} from "./columns";
+import { Annotation, isAbundanceColumn, PAxisName, PColumnName, readAnnotation } from "./columns";
 import { blockDataModel } from "./dataModel";
 import type { BlockArgs, BlockData } from "./types";
 
 export { blockDataModel } from "./dataModel";
 export * from "./types";
 
-const inputAnchorSpecs = [
+const inputAnchorSelectors: RelaxedColumnSelector[] = [
   {
     axes: [{ name: PAxisName.SampleId }, { name: PAxisName.VDJ.ClonotypeKey }],
     annotations: { [Annotation.IsAnchor]: "true" },
@@ -79,8 +71,10 @@ export const platforma = BlockModelV3.create(blockDataModel)
     };
   })
 
-  .output("inputOptions", (ctx) =>
-    ctx.resultPool.getOptions(inputAnchorSpecs, { refsWithEnrichments: true }),
+  .output("inputOptions", () =>
+    deriveColumnOptions(
+      ColumnsCollection(["result_pool"]).filter({ include: inputAnchorSelectors }),
+    ),
   )
 
   .output("annotationsIsComputing", (ctx) => {
@@ -97,30 +91,23 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .output("overlapColumns", (ctx) => {
     if (ctx.data.inputAnchor === undefined) return undefined;
-    const result = findOverlapMatches(ctx, ctx.data.inputAnchor);
+    const result = findOverlapMatches(ctx.data.inputAnchor);
     if (!result) return undefined;
 
     // Annotation results must not appear as filter inputs for their own definition.
-    const variants = result.variants.filter(
-      (m) => m.column.spec.name !== PColumnName.AnnotationResult,
-    );
-
-    const entries = variants.map((m) => ({
-      id: m.column.id,
-      spec: m.column.spec,
-      data: m.column.data?.get(),
-    })) as PColumn<PColumnDataUniversal>[];
-    if (entries.length === 0) return undefined;
+    const variants = result.collection
+      .filter({ exclude: { name: { type: "exact", value: PColumnName.AnnotationResult } } })
+      .getColumns();
+    if (variants.length === 0) return undefined;
 
     return {
-      pFrame: ctx.createPFrame(entries),
+      pFrame: ctx.createPFrame(variants.map((c) => c.id)),
       columns: buildFilterUiColumns(variants, result.anchorSpec.axesSpec),
     };
   })
 
   .outputWithStatus("overlapTable", (ctx) => {
     if (ctx.data.inputAnchor === undefined) return undefined;
-
     // Include prerun annotations once ready — addSource silently drops unresolved
     // accessors, so passing them earlier only churns the table descriptor.
     const annotation = ctx.prerun?.resolve({
@@ -128,52 +115,53 @@ export const platforma = BlockModelV3.create(blockDataModel)
       assertFieldType: "Input",
       allowPermanentAbsence: true,
     });
-    const extraSources = annotation?.getIsReadyOrError() ? [annotation] : [];
-    const result = findOverlapMatches(ctx, ctx.data.inputAnchor, extraSources);
+    const extraSources = annotation?.getIsReadyOrError() ? [annotation] : undefined;
+    const result = findOverlapMatches(ctx.data.inputAnchor, extraSources);
     if (!result) return undefined;
 
-    const { variants } = result;
+    const columns = result.collection.getColumns();
 
     // Direct multi-axis abundance columns split by sampleId (axis 0).
     const isAbundanceToSplit = (spec: PColumnSpec) =>
       isAbundanceColumn(spec) && spec.axesSpec.length > 1;
 
-    // Variants from non-split direct paths and from linked paths.
-    const nonSplitDirect: ReturnType<typeof toTableColumnVariant>[] = [];
-    const linked: ReturnType<typeof toTableColumnVariant>[] = [];
-    const splitInputs: ColumnSnapshot<PObjectId>[] = [];
+    // Leaves go to primary; wrapped (linker-reachable) recipes become secondary.
+    const splitInputs: ColumnRecipe[] = [];
+    const directLeaves: ColumnRecipe[] = [];
+    const wrappedRecipes: ColumnRecipe[] = [];
 
-    for (const v of variants) {
-      if ((v.path?.length ?? 0) === 0 && isAbundanceToSplit(v.column.spec)) {
-        splitInputs.push(v.column);
-      } else if ((v.path?.length ?? 0) === 0) {
-        nonSplitDirect.push(toTableColumnVariant(v, false));
+    for (const c of columns) {
+      if (isLeafColumn(c)) {
+        if (isAbundanceToSplit(c.getSpec())) {
+          splitInputs.push(c);
+        } else {
+          directLeaves.push(c);
+        }
       } else {
-        linked.push(toTableColumnVariant(v, false));
+        wrappedRecipes.push(c);
       }
     }
 
-    const splitColumns = splitByPartition(ctx, splitInputs, 0);
-    if (!splitColumns) return undefined;
-
-    const splitSnapshots = splitColumns.map((col) => ({
-      column: {
-        id: col.id,
-        spec: col.spec,
-        data: col.data,
-        dataStatus: col.dataStatus,
-      },
-      isPrimary: true,
-    }));
+    const splitRecipes = expandByPartition(splitInputs, [{ idx: 0 }], {
+      axisValuesLabels: deriveAxisValuesLabels(),
+    });
+    if (!splitRecipes) return undefined;
 
     return createPlDataTableV3(ctx, {
-      columns: [...splitSnapshots, ...nonSplitDirect, ...linked],
+      primaryColumns: [...splitRecipes, ...directLeaves],
+      columns: wrappedRecipes,
       primaryJoinType: "full",
       tableState: ctx.data.overlapTableState,
       displayOptions: {
         visibility: [
+          // Sample-count columns stay default — explicit match first wins.
           {
-            match: (spec: PColumnSpec) => isAbundanceColumn(spec) && !isSampleCountColumn(spec),
+            match: { name: "^(pl7\\.app/vdj/sampleCount|pl7\\.app/sampleCount)$" },
+            visibility: "default",
+          },
+          // Other abundance columns drop to optional.
+          {
+            match: { annotations: { [Annotation.IsAbundance]: "true" } },
             visibility: "optional",
           },
         ],
@@ -185,7 +173,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     if (ctx.data.inputAnchor === undefined) return undefined;
     return createPlDataTableV3(ctx, {
       columns: {
-        anchors: { main: ctx.data.inputAnchor },
+        anchors: { main: ctx.data.inputAnchor as unknown as PObjectId },
         selector: {
           mode: "enrichment",
           exclude: [
@@ -206,11 +194,13 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .output("sampleTableSheets", (ctx) => {
     if (ctx.data.inputAnchor === undefined) return undefined;
-    const anchor = ctx.resultPool.getPColumnByRef(ctx.data.inputAnchor);
+    const anchor = Column(ctx.data.inputAnchor);
     if (!anchor) return undefined;
-    const samples = getUniquePartitionKeys(anchor.data)?.[0];
+    const data = getLeafColumnData(anchor);
+    if (!(data instanceof TreeNodeAccessor)) return undefined;
+    const samples = getUniquePartitionKeys(data)?.[0];
     if (!samples) return undefined;
-    return [createPlDataTableSheet(ctx, anchor.spec.axesSpec[0], samples)];
+    return [createPlDataTableSheet(ctx, anchor.getSpec().axesSpec[0], samples)];
   })
 
   .outputWithStatus("statsTable", (ctx) => {
@@ -229,30 +219,23 @@ export const platforma = BlockModelV3.create(blockDataModel)
       return undefined;
     }
 
-    // sampleStats is keyed on [sampleId, annotationKey] — split by sampleId
-    // so each sample becomes its own annotation-keyed column set that joins
-    // with annotationStats on annotationKey.
-    const annotationSnapshots = new OutputColumnProvider(annotationStatsPf).getAllColumns();
-    const splitSampleSnapshots = splitByPartition(
-      ctx,
-      new OutputColumnProvider(sampleStatsPf).getAllColumns(),
-      0,
-    );
-    if (splitSampleSnapshots === undefined) return undefined;
+    const annotationRecipes = ColumnsCollection([annotationStatsPf]).getColumns();
+    const sampleRecipes = ColumnsCollection([sampleStatsPf]).getColumns();
+
+    // sampleStats is keyed on [sampleId, annotationKey] — split by sampleId so
+    // each sample becomes its own annotation-keyed column set that joins with
+    // annotationStats on annotationKey.
+    const sampleInputs = sampleRecipes.filter(isLeafColumn);
+    if (sampleInputs.length !== sampleRecipes.length) return undefined;
+
+    const splitSampleRecipes = expandByPartition(sampleInputs, [{ idx: 0 }], {
+      axisValuesLabels: deriveAxisValuesLabels(),
+    });
+    if (splitSampleRecipes === undefined) return undefined;
 
     return createPlDataTableV3(ctx, {
-      columns: [...annotationSnapshots, ...splitSampleSnapshots].map((s) => ({
-        column: {
-          id: s.id as unknown as DiscoveredPColumnId,
-          spec: s.spec,
-          data: s.data,
-          dataStatus: s.dataStatus,
-        },
-        path: [],
-        qualifications: { forHit: [], forQueries: {} },
-        originalId: s.id,
-        isPrimary: true,
-      })),
+      primaryColumns: [...annotationRecipes, ...splitSampleRecipes],
+      columns: [],
       tableState: ctx.data.statsTableState,
     });
   })
@@ -267,18 +250,16 @@ export const platforma = BlockModelV3.create(blockDataModel)
     ];
   })
 
-  .enriches((args) =>
-    args.inputAnchor !== undefined && args.annotationSpec.steps.length > 0
-      ? [args.inputAnchor]
-      : [],
-  )
+  .enriches((args) => {
+    if (args.inputAnchor === undefined || args.annotationSpec.steps.length === 0) return [];
+    const ref = universalIdToPlRef(args.inputAnchor);
+    return ref ? [ref] : [];
+  })
 
   .output(
     "modality",
     (ctx) => {
-      const spec = ctx.data.inputAnchor
-        ? ctx.resultPool.getPColumnSpecByRef(ctx.data.inputAnchor)
-        : undefined;
+      const spec = ctx.data.inputAnchor ? Column(ctx.data.inputAnchor)?.getSpec() : undefined;
       if (!spec) return undefined;
       for (const ax of spec.axesSpec) {
         if (ax.name === "pl7.app/variantKey") return "peptide";
@@ -299,21 +280,10 @@ export const platforma = BlockModelV3.create(blockDataModel)
   )
 
   .title((ctx) => {
-    try {
-      if (hasCompiledSteps(ctx.data.annotationSpecUi)) {
-        return `Sequence Annotation - ${ctx.data.annotationSpecUi.title}`;
-      }
-      const { inputAnchor } = ctx.data;
-      if (inputAnchor) {
-        const options = ctx.resultPool.getOptions(inputAnchorSpecs, {
-          refsWithEnrichments: true,
-        });
-        const label = options.find((o) => plRefsEqual(o.ref, inputAnchor))?.label;
-        if (label) return `Sequence Browser - ${label}`;
-      }
-    } catch {
-      // render context may not be fully initialized yet
+    if (hasCompiledSteps(ctx.data.annotationSpecUi)) {
+      return `Sequence Annotation - ${ctx.data.annotationSpecUi.title}`;
     }
+
     return "Sequence Browser";
   })
 
@@ -322,20 +292,19 @@ export const platforma = BlockModelV3.create(blockDataModel)
 export type Platforma = typeof platforma;
 export type BlockOutputs = InferOutputsType<typeof platforma>;
 
-function buildFilterUiColumns(variants: readonly ColumnVariant[], anchorAxesSpec: AxesSpec) {
-  const distinctLabels = deriveDistinctLabels(
-    variants.map((v) => ({
-      spec: v.column.spec,
-      linkersPath: v.path?.map((step) => ({ spec: step.linker.spec })),
-    })),
-    { includeNativeLabel: true },
-  );
-  const labelSpecs = variants.map((v) => v.column.spec).filter((s) => s.name === PColumnName.Label);
-  const ret = variants.map((m, i) => {
-    const spec = m.column.spec;
+function buildFilterUiColumns(variants: readonly ColumnRecipe[], anchorAxesSpec: AxesSpec) {
+  // Each variant pays one host round-trip; cache locally to keep the rest of
+  // this function spec-access free.
+  const specs = variants.map((c) => c.getSpec());
+
+  const distinctLabels = deriveDistinctLabels(specs, { includeNativeLabel: true });
+  const labelSpecs = specs.filter((s) => s.name === PColumnName.Label);
+
+  const ret = variants.map((v, i) => {
+    const spec = specs[i];
     const axesSpec = spec.axesSpec;
     return {
-      id: m.column.id as SUniversalPColumnId,
+      id: v.id,
       spec,
       label: distinctLabels[i] ?? readAnnotation(spec, Annotation.Label) ?? "",
       axesToBeFixed:
@@ -357,74 +326,45 @@ function buildFilterUiColumns(variants: readonly ColumnVariant[], anchorAxesSpec
   return ret;
 }
 
-function splitByPartition<A, U>(
-  ctx: RenderCtxBase<A, U>,
-  snapshots: ColumnSnapshot<PObjectId>[],
-  splitAxisIdx: number,
-) {
-  const { items, complete } = expandByPartition(snapshots, [{ idx: splitAxisIdx }], {
-    axisLabels: (axisId) => ctx.resultPool.findLabels(axisId),
-  });
-  if (!complete || items.length === 0) return undefined;
-
-  const splitAxisName = snapshots[0].spec.axesSpec[splitAxisIdx].name;
-  return items.map((col) => {
-    const splitValue = getTrace(col.spec)[0]?.label ?? "";
-    return {
-      ...col,
-      id: `${col.id}#${splitValue}` as PObjectId,
-      spec: { ...col.spec, domain: { ...col.spec.domain, [splitAxisName]: splitValue } },
-    };
-  });
-}
-
-// Extra sources are added before ctx sources so prerun annotations participate.
-function findOverlapMatches<A, U>(
-  ctx: RenderCtxBase<A, U>,
-  inputAnchor: PlRef,
-  extraSources?: Parameters<ColumnCollectionBuilder["addSource"]>[0][],
-) {
-  const anchorSpec = ctx.resultPool.getPColumnSpecByRef(inputAnchor);
+/**
+ * Build the overlap discovery collection and resolve the anchor spec.
+ * Returns `{ collection, anchorSpec }` — the collection holds discovery
+ * survivors (still as host-side state, no specs fetched); per-output filters
+ * (e.g. dropping `AnnotationResult` for `overlapColumns`) refine it further.
+ */
+function findOverlapMatches(inputAnchor: ColumnUniversalId, extraSources?: TreeNodeAccessor[]) {
+  const anchorSpec = Column(inputAnchor)?.getSpec();
   if (!anchorSpec) return undefined;
 
-  const builder = new ColumnCollectionBuilder(ctx.getService("pframeSpec"));
-  if (extraSources) for (const src of extraSources) builder.addSource(src);
-  builder.addSources(collectCtxColumnSnapshotProviders(ctx));
+  // Default ctx triplet (outputs + prerun + result pool) plus any caller-
+  // supplied subtree (e.g. the prerun annotation accessor).
+  const sources: (TreeNodeAccessor | "current_block" | "result_pool")[] = [
+    "current_block",
+    "result_pool",
+  ];
+  if (extraSources) sources.unshift(...extraSources);
 
-  const collection = builder.build({ anchors: { main: anchorSpec } });
-  if (!collection) return undefined;
-
-  const matches = collection.findColumnVariants({
+  let collection = ColumnsCollection(sources).discover({
+    anchors: { main: anchorSpec },
     mode: "enrichment",
     exclude: [
-      { name: PColumnName.SequenceAnnotation },
-      { annotations: { [Annotation.IsSubset]: "true" } },
-      { axes: [{ name: anchorSpec.axesSpec[0].name }], partialAxesMatch: false },
+      { name: [{ type: "exact", value: PColumnName.SequenceAnnotation }] },
+      { annotations: { [Annotation.IsSubset]: [{ type: "exact", value: "true" }] } },
+      {
+        axes: [{ name: [{ type: "exact", value: anchorSpec.axesSpec[0].name }] }],
+        partialAxesMatch: false,
+      },
     ],
   });
-  collection.dispose();
 
   // Linked multi-axis columns (e.g. per-sample abundance on clusterId) bring
   // extra dimensions into the join and belong in the sample table instead.
-  const filtered = matches.filter(
-    (m) => (m.path?.length ?? 0) === 0 || m.column.spec.axesSpec.length === 1,
-  );
-  return { variants: filtered, anchorSpec };
-}
-
-function toTableColumnVariant(variant: ColumnVariant, isPrimary: boolean) {
-  const id = createDiscoveredPColumnId({
-    column: variant.column.id,
-    path: variant.path?.map((p) => ({ type: "linker" as const, column: p.linker.id })),
-    columnQualifications: variant.qualifications?.forHit,
-    queriesQualifications: variant.qualifications?.forQueries,
+  const survivors = collection.getColumns().filter((c) => {
+    return isLeafColumn(c) || c.getSpec().axesSpec.length === 1;
   });
-  return {
-    ...variant,
-    column: { ...variant.column, id },
-    originalId: variant.column.id,
-    isPrimary,
-  };
+  collection = ColumnsCollection([{ columns: survivors, isFinal: collection.isFinal() }]);
+
+  return { collection, anchorSpec };
 }
 
 function compileAnnotationSpec(ui: BlockData["annotationSpecUi"]): BlockArgs["annotationSpec"] {
@@ -441,4 +381,15 @@ function hasCompiledSteps(ui: BlockData["annotationSpecUi"]): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * `enriches` expects `PlRef[]`. Our `inputAnchor` is now a `ColumnUniversalId`
+ * — for result-pool leaves that is `createGlobalPObjectId(blockId, name)`,
+ * which is exactly the canonical JSON of `{ __isRef, blockId, name }`. Parse
+ * it back to recover the original `PlRef`.
+ */
+function universalIdToPlRef(id: ColumnUniversalId): PlRef | undefined {
+  const parsed = parseJsonSafely(id);
+  return isPlRef(parsed) ? parsed : undefined;
 }

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -104,24 +104,9 @@ export const platforma = BlockModelV3.create(blockDataModel)
       .getColumns();
     if (variants.length === 0) return undefined;
 
-    // Split multi-axis abundance columns per sample (axis 0) — same as
-    // `overlapTable` — so the filter offers per-sample "Number Of Reads /
-    // <sample>" entries instead of a single collapsed column.
-    const specs = variants.map((c) => c.getSpec());
-    const isSplittable = (c: ColumnRecipe, i: number) =>
-      isLeafColumn(c) && isAbundanceColumn(specs[i]) && specs[i].axesSpec.length > 1;
-    const splitInputs = variants.filter(isSplittable);
-    const rest = variants.filter((c, i) => !isSplittable(c, i));
-
-    const splitRecipes = expandByPartition(splitInputs, [{ idx: 0 }], {
-      axisValuesLabels: deriveAxisValuesLabels(),
-    });
-    if (!splitRecipes) return undefined;
-    const columns = [...splitRecipes, ...rest];
-
     return {
-      pFrame: ctx.createPFrame(columns.map((c) => c.id)),
-      columns: buildFilterUiColumns(columns, result.anchorSpec.axesSpec),
+      pFrame: ctx.createPFrame(variants.map((c) => c.id)),
+      columns: buildFilterUiColumns(variants, result.anchorSpec.axesSpec),
     };
   })
 

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -53,20 +53,24 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
     if (data.inputAnchor === undefined) throw new Error("No input anchor");
+    const inputAnchor = universalIdToPlRef(data.inputAnchor);
+    if (!inputAnchor) throw new Error("Input anchor is not a result-pool reference");
     const annotationSpec = compileAnnotationSpec(data.annotationSpecUi);
     if (annotationSpec.steps.length === 0) throw new Error("No annotation steps");
     return {
-      inputAnchor: data.inputAnchor,
+      inputAnchor,
       annotationSpec,
     };
   })
 
   .prerunArgs((data) => {
     if (data.inputAnchor === undefined) return undefined;
+    const inputAnchor = universalIdToPlRef(data.inputAnchor);
+    if (!inputAnchor) return undefined;
     const annotationSpec = compileAnnotationSpec(data.annotationSpecUi);
     if (annotationSpec.steps.length === 0) return undefined;
     return {
-      inputAnchor: data.inputAnchor,
+      inputAnchor,
       annotationSpec,
     };
   })
@@ -100,9 +104,24 @@ export const platforma = BlockModelV3.create(blockDataModel)
       .getColumns();
     if (variants.length === 0) return undefined;
 
+    // Split multi-axis abundance columns per sample (axis 0) — same as
+    // `overlapTable` — so the filter offers per-sample "Number Of Reads /
+    // <sample>" entries instead of a single collapsed column.
+    const specs = variants.map((c) => c.getSpec());
+    const isSplittable = (c: ColumnRecipe, i: number) =>
+      isLeafColumn(c) && isAbundanceColumn(specs[i]) && specs[i].axesSpec.length > 1;
+    const splitInputs = variants.filter(isSplittable);
+    const rest = variants.filter((c, i) => !isSplittable(c, i));
+
+    const splitRecipes = expandByPartition(splitInputs, [{ idx: 0 }], {
+      axisValuesLabels: deriveAxisValuesLabels(),
+    });
+    if (!splitRecipes) return undefined;
+    const columns = [...splitRecipes, ...rest];
+
     return {
-      pFrame: ctx.createPFrame(variants.map((c) => c.id)),
-      columns: buildFilterUiColumns(variants, result.anchorSpec.axesSpec),
+      pFrame: ctx.createPFrame(columns.map((c) => c.id)),
+      columns: buildFilterUiColumns(columns, result.anchorSpec.axesSpec),
     };
   })
 
@@ -252,8 +271,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .enriches((args) => {
     if (args.inputAnchor === undefined || args.annotationSpec.steps.length === 0) return [];
-    const ref = universalIdToPlRef(args.inputAnchor);
-    return ref ? [ref] : [];
+    return [args.inputAnchor];
   })
 
   .output(

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   AnnotationSpec as _AnnotationSpec,
   AnnotationSpecUi as _AnnotationSpecUi,
+  ColumnUniversalId,
   FilterSpec as _FilterSpec,
   FilterSpecLeaf,
   FilterSpecUi as _FilterSpecUI,
@@ -22,13 +23,13 @@ export type AnnotationSpec = _AnnotationSpec & { defaultValue?: string };
 
 /** Args passed to the workflow — the output shape of `.args(...)`. */
 export type BlockArgs = {
-  inputAnchor?: PlRef;
+  inputAnchor?: ColumnUniversalId;
   annotationSpec: AnnotationSpec;
 };
 
 /** Unified V3 data model: block args plus UI state in one object. */
 export type BlockData = {
-  inputAnchor?: PlRef;
+  inputAnchor?: ColumnUniversalId;
   settingsOpen: boolean;
   overlapTableState: PlDataTableStateV2;
   sampleTableState: PlDataTableStateV2;

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -21,9 +21,14 @@ export type FilterSpecUI = _FilterSpecUI<Extract<FilterSpec, { type: "and" | "or
 export type AnnotationSpecUi = _AnnotationSpecUi<FilterSpecUI> & { defaultValue?: string };
 export type AnnotationSpec = _AnnotationSpec & { defaultValue?: string };
 
-/** Args passed to the workflow — the output shape of `.args(...)`. */
+/**
+ * Args passed to the workflow — the output shape of `.args(...)`.
+ * `inputAnchor` is a `PlRef` (not the UI-facing `ColumnUniversalId`): the
+ * workflow resolves the anchor by reference (blockId + name) via the bundle
+ * builder, which requires a ref map, not an opaque universal id string.
+ */
 export type BlockArgs = {
-  inputAnchor?: ColumnUniversalId;
+  inputAnchor?: PlRef;
   annotationSpec: AnnotationSpec;
 };
 

--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
     "oxfmt": "*",
     "oxlint": "*"
   },
-  "packageManager": "pnpm@9.12.0"
+  "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,11 +37,11 @@ catalogs:
       specifier: 4.0.18
       version: 4.0.18
     '@platforma-sdk/test':
-      specifier: 1.80.2
-      version: 1.80.2
+      specifier: 1.80.3
+      version: 1.80.3
     '@platforma-sdk/ui-vue':
-      specifier: 1.80.2
-      version: 1.80.2
+      specifier: 1.80.4
+      version: 1.80.4
     '@platforma-sdk/workflow-tengo':
       specifier: 6.7.2
       version: 6.7.2
@@ -205,7 +205,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.80.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
@@ -223,7 +223,7 @@ importers:
         version: 1.80.2
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.80.2(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+        version: 1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -279,7 +279,7 @@ importers:
         version: 4.0.18
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.80.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -905,9 +905,6 @@ packages:
   '@milaboratories/build-configs@2.0.0':
     resolution: {integrity: sha512-oec/O8ltsDkP+tbaLXuWZUHg7vW3/e60R4gMLvKF5f9wqXSU/CDe08zG4bUpxEW8xjYQzTyZBOC2iN6cTwNxEA==}
 
-  '@milaboratories/columns-collection-driver@0.2.0':
-    resolution: {integrity: sha512-3u4g//TnDrMSh7j6YTUI7sK5b7pMEDTu5TfwxP3ANn7bGkalkI2+++iskbG461rSwXv5HK9zy7hVuMIuffqj/Q==}
-
   '@milaboratories/columns-collection-driver@0.2.1':
     resolution: {integrity: sha512-CYdDAhmB01jYq0IXJmbMbA/yTfqSkzwRs0ZJxoSvnzvlu1doc63VIXSvhHOw9b70usR5EFVprR2PvPMTRnjeQQ==}
 
@@ -919,10 +916,6 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/helpers@1.14.3':
-    resolution: {integrity: sha512-nZv+n+orVzA/GimDTNj6Yjb52+Wu5f/Kf2z6UCGXni6KTquLBfQhi3AFB1mLE7hkUYPvKU6LxuRY02CQMQiTVA==}
-    engines: {node: '>=22'}
-
   '@milaboratories/helpers@1.14.4':
     resolution: {integrity: sha512-0mS5GQAQYUab0qj1C6+IXafNJhL1ahnhPBmIkLq9VqJU8p9jNZ7KC5ln4/pl0tK47brdPljCLEiLg8IdSa6wFw==}
     engines: {node: '>=22'}
@@ -930,9 +923,6 @@ packages:
   '@milaboratories/pf-driver@1.8.2':
     resolution: {integrity: sha512-K5jKzqFfsOJL051U1VAg2Iy9iE01Hwm+FtRb2/PcB0DV3VItIozXRF/mvcXKDHbSCLcPcRGqZjtEF3kMczd+sA==}
     engines: {node: '>=22.19.0'}
-
-  '@milaboratories/pf-spec-driver@1.4.19':
-    resolution: {integrity: sha512-dfQIe9qMFuoRRNauG+1suZhuFBHeRmaVBCk+BqnlTs/mMPnKnXsZAmADsFbQYxl2qS5nHDerzhBPBpYa+Ippxg==}
 
   '@milaboratories/pf-spec-driver@1.4.21':
     resolution: {integrity: sha512-JuYVQKs4aia8DA8MVqdImu+Ho+uTwwOqIaJ3VVPMpCMo3QAH9jZP+wGlkklSwow4d+27Y8L2RJN/1dcPr56GZw==}
@@ -944,18 +934,11 @@ packages:
     resolution: {integrity: sha512-cGByUULBA/JiwyFEBZrVNOEbnbrMPWWHCWLprRKlVWlmDMaRmsVft/tFpnle46BhDZWpoWbaKEZ8NGOtGqDCXw==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.52':
-    resolution: {integrity: sha512-0rb0We6Q/aqrHJ062dayvLb4RExODZdqfsVWdzeHq23alY5TjJRMWsO9aKQpPnOuUKjAimdjlp+Ldq9TVhbEtg==}
+  '@milaboratories/pframes-rs-wasip2@1.1.35':
+    resolution: {integrity: sha512-kcR9YLWAbKYSpksPOoJWkcrkSiUUAEKj/Wuyc9aFsd2bNbWcIb7mLGptFOuvhLn07bZHn0oNcVgupEqd/6Ftbw==}
 
   '@milaboratories/pframes-rs-wasip2@1.1.55':
     resolution: {integrity: sha512-mwKTmcDiuN6Id2h+oxKX2W5igFhMxDvRZs4clsxhPTYZASSROrvsSsaoXS81meqfC0phx+BUaRpdrkVQIKSdxQ==}
-
-  '@milaboratories/pframes-rs-wasm@1.1.52':
-    resolution: {integrity: sha512-Wn8/LJxcsvWSSpdymdebWrBnmgu9wAbzvOiHCtXz7Aqt1M2T8Xp9a7CprzCYx+EvhSuAuoxbq6naxkPsQrbkvg==}
-    peerDependencies:
-      '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.7
 
   '@milaboratories/pframes-rs-wasm@1.1.55':
     resolution: {integrity: sha512-kVOL+eAasfeiui5lQ5G92nsSiTNSsOnl1m+4my0tmbR7VTCa15dn1kd5RcXS3/8YO5oEcnGlCUhnu5kKMtweEw==}
@@ -995,8 +978,8 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.66.2':
-    resolution: {integrity: sha512-N8nZ9Ch3nxm3b4lIqNRiSJj3FiPXH1O8tJVnNFwMkLcUnzkQnWEnOzrZtZaBIMgwZEK2tl3LKwnvEF9RQ3T5kQ==}
+  '@milaboratories/pl-middle-layer@1.66.3':
+    resolution: {integrity: sha512-6nkpOyjWXPsHxDpOOFDDpicCSLP4XwgdfN3xVKtbkMUrIPUEpplmje3xe1JA3fR2I22zBBpyEj2r6pI/Jg9Ajg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-model-backend@1.4.16':
@@ -1008,14 +991,8 @@ packages:
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
-  '@milaboratories/pl-model-common@1.47.0':
-    resolution: {integrity: sha512-HmUwNjiA6jo66NhKrl6SLnAoobLuEqw5kyna7aiMC9H3PH1vRk5Jzbvlx83FjQGXsjCIzqEoJJKWNIMXbb2VEg==}
-
   '@milaboratories/pl-model-common@1.47.1':
     resolution: {integrity: sha512-5F9I8JvUPRJ2HEzz5MmTio6JFYnhYoMVHfToh2NyXyOyQgAF6jhOzZBOsrEig9NfCPZBRB7v6UjmIK43dG4o/g==}
-
-  '@milaboratories/pl-model-middle-layer@1.30.12':
-    resolution: {integrity: sha512-+0c9MQ64fivMjUBwX1jKzafzTDAGSc5jRFAt4qnX7v1ysefotc+BD/ObukVFbafxHu93I4hzf4ERw10xo8KDcw==}
 
   '@milaboratories/pl-model-middle-layer@1.30.13':
     resolution: {integrity: sha512-owQVozyub/6aKgk+yce+9sDK+t0HrpLbnlKJqQjYJahuhoju8j6VMY17AWgvADSDCiI3gnp/Tm/I4Ur6ySs1Cg==}
@@ -1029,9 +1006,6 @@ packages:
 
   '@milaboratories/ptabler-expression-js@1.1.5':
     resolution: {integrity: sha512-EBnOKHbXNhR+dGeKvUY84eEdXgZeLrunJdlNpauXWa+mnaCOwF2J1xxjberfeAi36xS90IoeW6Hy7pi9k0TycQ==}
-
-  '@milaboratories/ptabler-expression-js@1.2.34':
-    resolution: {integrity: sha512-MOLdW0Ntn92cvdZMhwe09rgAgMf16jJMKKD/DQp1Oq3aZCEZiJ2psj4pmmrGToJ9d17+4fgqD/nXV7VTwvKWgw==}
 
   '@milaboratories/ptabler-expression-js@1.2.35':
     resolution: {integrity: sha512-nTVNYgNHuUswPnAe8GFAitbewNVMHaxhAncQ3yMYfGzsGgZupQyGV6K1DHVkzMAwNwVFVLwIbiPMY58en03XWQ==}
@@ -1057,9 +1031,6 @@ packages:
   '@milaboratories/ts-helpers@1.8.5':
     resolution: {integrity: sha512-vZDcIBta7I935VjKk6qGdhpjz2pWXe5CbWv1UUmPrcG8wsunDpWuet8/Gi75N97CpcLDc2LLHd/url9K8ZNpAg==}
     engines: {node: '>=22.19.0'}
-
-  '@milaboratories/uikit@2.15.15':
-    resolution: {integrity: sha512-JCuLoQaysQyvAMj5c0SqLj8Wd1e7UBYN/mzZICDHpDjFDue2Sl/yfHsabWSfRb3VrkkDD9p0z6INWnWZv7JCyg==}
 
   '@milaboratories/uikit@2.15.16':
     resolution: {integrity: sha512-HOl1YsPKHpj3izKAs0hEvVtFE8ZbrOnD5KsAqSHxvipQyfAdOLbfB7ak6XPdPKbgsvH5opfMws7usryR6Nlulw==}
@@ -1404,9 +1375,6 @@ packages:
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.5':
     resolution: {integrity: sha512-8KDVwfi00gqNU8r92XxecVleu/Jk5RoylwOMsoUatbkyTVL/+yQavdAgXc5aRLop07AvG3cFpHXW8ZqYBc7zbQ==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.18':
-    resolution: {integrity: sha512-u/Z1zUx52NlpS3eCIZF8roEWKMmQkYNVTFiTTUfHH9Jki6YFjl/9yiUu9pGqAADhZ9wX0F3JNW4Q2u4Qkkb2Gw==}
-
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.19':
     resolution: {integrity: sha512-h/FBLELZT6PJZnWtwvcy8bQrpZ2A6xWSVSjyccqb3QolHSbeuwi5UpUph8UxdDYNmWSCH0zR/zE2hFypgk21xA==}
 
@@ -1496,9 +1464,6 @@ packages:
   '@platforma-sdk/model@1.46.0':
     resolution: {integrity: sha512-tY1kad46WKvpGHSPoOXfQ3FuBs62CL7rQLrBlzEhfQRAL96dWbycORbH1oo82vEzW39f7F6Q5kgg14Yx6uL/tQ==}
 
-  '@platforma-sdk/model@1.80.0':
-    resolution: {integrity: sha512-wqn721wKdZCy5FWB8uDZDgKwofQSPCjOHBCv4EaaIRB78URR43cKtKXl+MrUV8BxgqwMa9R8EBv2wfyA48s3bA==}
-
   '@platforma-sdk/model@1.80.2':
     resolution: {integrity: sha512-aQGVxjxw7y34U0ZuboIYASodJMZ1yTjXH2y44bCdeTeS/r81YBBmGrF6BQhHHVjIOIhaIlWHRBIhd9AJo42aWQ==}
 
@@ -1510,17 +1475,14 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.80.2':
-    resolution: {integrity: sha512-tEdcYLl4lp5ywXse5YMpCGxekGyVS4ZMmiMijsJ6lBDpBHJEm8bDioRXQyBbc2Cg3RKnVPjZZxOny+48n4RdPw==}
+  '@platforma-sdk/test@1.80.3':
+    resolution: {integrity: sha512-q0hETSlBMsEM53/6Xs29lAar+XJrrwZS6mmau1LSfDfy9OHdGfZ7YEpYDyRzfITlKOV1Z0WqLC0s21gtLQAMIA==}
 
-  '@platforma-sdk/ui-vue@1.80.0':
-    resolution: {integrity: sha512-NWhWcnxMOxnMqqFaDNdqQnjzo+0xqGpjS5WrKlgtrEjFR71aRDfie0AQk+lBAQ+kOpYBpyRpcZM3Et4zjloupg==}
+  '@platforma-sdk/ui-vue@1.80.4':
+    resolution: {integrity: sha512-DQbuO3fAJ3CQxiJkXMiNuo1Qyd/C92AatOZX90ElLFohXiP3XbJNXNjrIxypzsUc850dKkqbPjKd0JTzD12E9w==}
 
-  '@platforma-sdk/ui-vue@1.80.2':
-    resolution: {integrity: sha512-aTvUEpwgHv/bul8W/h2tLgmZfrapnNV5SkDjVEFSe+jh9B9I40hxNPrporltAcShq9xqa9DhxP8/HctnzfnKdA==}
-
-  '@platforma-sdk/workflow-tengo@5.24.0':
-    resolution: {integrity: sha512-LFZbnHHU3yBulorph6867ZF0P8mtm0scEXQxplNJXxylMJp09uHSCKp/1JHhsMK7v8/iEY0Tph7RgVJXVSwmoA==}
+  '@platforma-sdk/workflow-tengo@5.26.0':
+    resolution: {integrity: sha512-lXoFzD0LsQqEF9WUkA48avAY7LOK9WdP7sIc/Bymu1fOm4peXEWWZFW7fYckCPhHEAwcyzjqh7jdE8pVXrfzvw==}
 
   '@platforma-sdk/workflow-tengo@5.6.3':
     resolution: {integrity: sha512-yRRCk6rivpBncX6kXg/6qVWCqQos9aU+30uXN4Ndt5UwEHc5rtNowvZzb5R8wMbIOlHONbp1azJkw1k9tvKbVg==}
@@ -5709,11 +5671,6 @@ snapshots:
 
   '@milaboratories/build-configs@2.0.0': {}
 
-  '@milaboratories/columns-collection-driver@0.2.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-model-common': 1.47.0
-
   '@milaboratories/columns-collection-driver@0.2.1':
     dependencies:
       '@milaboratories/helpers': 1.14.4
@@ -5727,8 +5684,6 @@ snapshots:
       utility-types: 3.11.0
 
   '@milaboratories/helpers@1.14.2': {}
-
-  '@milaboratories/helpers@1.14.3': {}
 
   '@milaboratories/helpers@1.14.4': {}
 
@@ -5746,16 +5701,6 @@ snapshots:
       - '@bytecodealliance/preview2-shim'
       - encoding
       - supports-color
-
-  '@milaboratories/pf-spec-driver@1.4.19(@bytecodealliance/preview2-shim@0.17.8)':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/pl-model-middle-layer': 1.30.12
-      '@noble/hashes': 2.0.1
-    transitivePeerDependencies:
-      - '@bytecodealliance/preview2-shim'
 
   '@milaboratories/pf-spec-driver@1.4.21(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
@@ -5787,16 +5732,9 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.52': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.35': {}
 
   '@milaboratories/pframes-rs-wasip2@1.1.55': {}
-
-  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)':
-    dependencies:
-      '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/pl-model-middle-layer': 1.30.12
 
   '@milaboratories/pframes-rs-wasm@1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)':
     dependencies:
@@ -5897,7 +5835,7 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.66.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.66.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
       '@milaboratories/columns-collection-driver': 0.2.1
       '@milaboratories/computable': 2.9.7
@@ -5957,28 +5895,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.47.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-error-like': 1.12.10
-      canonicalize: 2.1.0
-      es-toolkit: 1.41.0
-      zod: 3.25.76
-
   '@milaboratories/pl-model-common@1.47.1':
     dependencies:
       '@milaboratories/helpers': 1.14.4
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       es-toolkit: 1.41.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-middle-layer@1.30.12':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-model-common': 1.47.0
-      es-toolkit: 1.41.0
-      utility-types: 3.11.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.30.13':
@@ -6010,10 +5932,6 @@ snapshots:
   '@milaboratories/ptabler-expression-js@1.1.5':
     dependencies:
       '@platforma-open/milaboratories.software-ptabler.schema': 1.12.5
-
-  '@milaboratories/ptabler-expression-js@1.2.34':
-    dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.18
 
   '@milaboratories/ptabler-expression-js@1.2.35':
     dependencies:
@@ -6155,40 +6073,6 @@ snapshots:
       '@milaboratories/helpers': 1.14.4
       canonicalize: 2.1.0
       denque: 2.1.0
-
-  '@milaboratories/uikit@2.15.15(typescript@5.9.3)':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@platforma-sdk/model': 1.80.0
-      '@types/d3-array': 3.2.2
-      '@types/d3-axis': 3.0.6
-      '@types/d3-scale': 4.0.9
-      '@types/d3-selection': 3.0.11
-      '@types/sortablejs': 1.15.9
-      '@vue/test-utils': 2.4.6
-      '@vueuse/core': 13.9.0(vue@3.5.24(typescript@5.9.3))
-      '@vueuse/integrations': 13.9.0(sortablejs@1.15.7)(vue@3.5.24(typescript@5.9.3))
-      canonicalize: 2.1.0
-      d3-array: 3.2.4
-      d3-axis: 3.0.0
-      d3-scale: 4.0.2
-      d3-selection: 3.0.0
-      resize-observer-polyfill: 1.5.1
-      sortablejs: 1.15.7
-      vue: 3.5.24(typescript@5.9.3)
-    transitivePeerDependencies:
-      - async-validator
-      - axios
-      - change-case
-      - drauu
-      - focus-trap
-      - fuse.js
-      - idb-keyval
-      - jwt-decode
-      - nprogress
-      - qrcode
-      - typescript
-      - universal-cookie
 
   '@milaboratories/uikit@2.15.16(typescript@5.9.3)':
     dependencies:
@@ -6474,10 +6358,10 @@ snapshots:
 
   '@platforma-open/milaboratories.mixcr-clonotyping-2.ui@1.19.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/helpers': 1.14.4
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model': 1.20.0
       '@platforma-sdk/model': 1.80.2
-      '@platforma-sdk/ui-vue': 1.80.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@platforma-sdk/ui-vue': 1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@vueuse/core': 13.9.0(vue@3.5.25(typescript@5.9.3))
       ag-grid-enterprise: 34.1.2
       ag-grid-vue3: 34.1.2(vue@3.5.25(typescript@5.9.3))
@@ -6502,7 +6386,7 @@ snapshots:
   '@platforma-open/milaboratories.mixcr-clonotyping-2.workflow@3.17.1':
     dependencies:
       '@platforma-open/milaboratories.software-mixcr': 4.7.0-254-develop
-      '@platforma-sdk/workflow-tengo': 5.24.0
+      '@platforma-sdk/workflow-tengo': 5.26.0
 
   '@platforma-open/milaboratories.mixcr-clonotyping-2@2.12.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
@@ -6556,10 +6440,6 @@ snapshots:
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.5':
     dependencies:
       '@milaboratories/pl-model-common': 1.21.9
-
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.18':
-    dependencies:
-      '@milaboratories/pl-model-common': 1.47.0
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.19':
     dependencies:
@@ -6673,20 +6553,6 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@platforma-sdk/model@1.80.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/pl-model-middle-layer': 1.30.12
-      '@milaboratories/ptabler-expression-js': 1.2.34
-      canonicalize: 2.1.0
-      es-toolkit: 1.41.0
-      fast-json-patch: 3.1.1
-      lru-cache: 11.2.2
-      utility-types: 3.11.0
-      zod: 3.25.76
-
   '@platforma-sdk/model@1.80.2':
     dependencies:
       '@milaboratories/helpers': 1.14.4
@@ -6723,11 +6589,11 @@ snapshots:
       commander: 15.0.0
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.80.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.80.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
     dependencies:
       '@milaboratories/computable': 2.9.7
       '@milaboratories/pl-client': 3.14.2
-      '@milaboratories/pl-middle-layer': 1.66.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-middle-layer': 1.66.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
       '@milaboratories/pl-tree': 1.13.1
       '@platforma-sdk/model': 1.80.2
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
@@ -6751,44 +6617,7 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.80.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
-    dependencies:
-      '@milaboratories/columns-collection-driver': 0.2.0
-      '@milaboratories/pf-spec-driver': 1.4.19(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/uikit': 2.15.15(typescript@5.9.3)
-      '@platforma-sdk/model': 1.80.0
-      '@types/d3-format': 3.0.4
-      '@types/node': 24.5.2
-      '@types/semver': 7.7.1
-      '@vueuse/core': 13.9.0(vue@3.5.24(typescript@5.9.3))
-      '@zip.js/zip.js': 2.8.8
-      ag-grid-enterprise: 34.1.2
-      ag-grid-vue3: 34.1.2(vue@3.5.24(typescript@5.9.3))
-      canonicalize: 2.1.0
-      d3-format: 3.1.0
-      es-toolkit: 1.41.0
-      fast-json-patch: 3.1.1
-      immer: 11.1.4
-      lru-cache: 11.2.2
-      vue: 3.5.24(typescript@5.9.3)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@bytecodealliance/preview2-shim'
-      - async-validator
-      - axios
-      - change-case
-      - drauu
-      - focus-trap
-      - fuse.js
-      - idb-keyval
-      - jwt-decode
-      - nprogress
-      - qrcode
-      - typescript
-      - universal-cookie
-
-  '@platforma-sdk/ui-vue@1.80.2(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/columns-collection-driver': 0.2.1
       '@milaboratories/pf-spec-driver': 1.4.21(@bytecodealliance/preview2-shim@0.17.8)
@@ -6825,8 +6654,9 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.24.0':
+  '@platforma-sdk/workflow-tengo@5.26.0':
     dependencies:
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/software-pframes-conv': 2.2.9
       '@platforma-open/milaboratories.software-ptabler': 1.16.1
       '@platforma-open/milaboratories.software-ptexter': 1.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ catalogs:
       specifier: 2.0.0
       version: 2.0.0
     '@milaboratories/helpers':
-      specifier: 1.14.3
-      version: 1.14.3
+      specifier: 1.14.4
+      version: 1.14.4
     '@milaboratories/pl-model-common':
-      specifier: 1.47.0
-      version: 1.47.0
+      specifier: 1.47.1
+      version: 1.47.1
     '@milaboratories/ts-builder':
       specifier: 1.6.0
       version: 1.6.0
@@ -28,23 +28,23 @@ catalogs:
       specifier: ^1.2.3
       version: 1.2.3
     '@platforma-sdk/block-tools':
-      specifier: 2.12.5
-      version: 2.12.5
+      specifier: 2.12.6
+      version: 2.12.6
     '@platforma-sdk/model':
-      specifier: 1.80.0
-      version: 1.80.0
+      specifier: 1.80.2
+      version: 1.80.2
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.17
-      version: 4.0.17
+      specifier: 4.0.18
+      version: 4.0.18
     '@platforma-sdk/test':
-      specifier: 1.80.0
-      version: 1.80.0
+      specifier: 1.80.2
+      version: 1.80.2
     '@platforma-sdk/ui-vue':
-      specifier: 1.80.0
-      version: 1.80.0
+      specifier: 1.80.2
+      version: 1.80.2
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.7.1
-      version: 6.7.1
+      specifier: 6.7.2
+      version: 6.7.2
     '@types/lodash':
       specifier: ^4.17.20
       version: 4.17.20
@@ -98,7 +98,7 @@ importers:
         version: 1.6.0(@types/node@24.5.2)(rollup@4.46.2)(sass-embedded@1.89.2)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.5(@types/node@24.5.2)
+        version: 2.12.6(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -128,10 +128,10 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.5(@types/node@24.5.2)
+        version: 2.12.6(@types/node@24.5.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.80.0
+        version: 1.80.2
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -143,10 +143,10 @@ importers:
     dependencies:
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.3
+        version: 1.14.4
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.80.0
+        version: 1.80.2
       '@types/lodash.omit':
         specifier: ^4.5.9
         version: 4.5.9
@@ -168,7 +168,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.5(@types/node@24.5.2)
+        version: 2.12.6(@types/node@24.5.2)
 
   test:
     dependencies:
@@ -189,7 +189,7 @@ importers:
         version: 2.4.1
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.80.0
+        version: 1.80.2
       this-block:
         specifier: workspace:@platforma-open/milaboratories.clonotype-browser-3@*
         version: link:../block
@@ -205,7 +205,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.80.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
@@ -214,16 +214,16 @@ importers:
     dependencies:
       '@milaboratories/pl-model-common':
         specifier: 'catalog:'
-        version: 1.47.0
+        version: 1.47.1
       '@platforma-open/milaboratories.clonotype-browser-3.model':
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.80.0
+        version: 1.80.2
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.80.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+        version: 1.80.2(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -251,7 +251,7 @@ importers:
         version: 2.0.0
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.3
+        version: 1.14.4
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
         version: 1.6.0(@types/node@24.5.2)(rollup@4.46.2)(sass-embedded@1.89.2)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.1)
@@ -272,14 +272,14 @@ importers:
         version: 1.2.3
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.7.1
+        version: 6.7.2
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.17
+        version: 4.0.18
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.80.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -908,8 +908,11 @@ packages:
   '@milaboratories/columns-collection-driver@0.2.0':
     resolution: {integrity: sha512-3u4g//TnDrMSh7j6YTUI7sK5b7pMEDTu5TfwxP3ANn7bGkalkI2+++iskbG461rSwXv5HK9zy7hVuMIuffqj/Q==}
 
-  '@milaboratories/computable@2.9.6':
-    resolution: {integrity: sha512-Au+84jboSJMM2k39mWUFCtPl2wkislD1fLbb45du1PcAg1GSER1ThSLoBpZUQC2oiTt804WmbzhZ2yaoVZiVLQ==}
+  '@milaboratories/columns-collection-driver@0.2.1':
+    resolution: {integrity: sha512-CYdDAhmB01jYq0IXJmbMbA/yTfqSkzwRs0ZJxoSvnzvlu1doc63VIXSvhHOw9b70usR5EFVprR2PvPMTRnjeQQ==}
+
+  '@milaboratories/computable@2.9.7':
+    resolution: {integrity: sha512-uCMretdt4okbKWkU0aZ0+NHH3hN0wzi2ZIkAvwqha0ZTxUqKilDOlZNAL6QLbmT/7vQs9geAj4amlwSgzkMoww==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/helpers@1.14.2':
@@ -920,25 +923,32 @@ packages:
     resolution: {integrity: sha512-nZv+n+orVzA/GimDTNj6Yjb52+Wu5f/Kf2z6UCGXni6KTquLBfQhi3AFB1mLE7hkUYPvKU6LxuRY02CQMQiTVA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pf-driver@1.8.0':
-    resolution: {integrity: sha512-fosgbyM72hySHW5gkPN2HHSTSVFaiLo2CF75bDiQ/6KKCuJMUnP9kxcxMIULz/ujS4xQGoBGzZdlbdnKRoZAqA==}
-    engines: {node: '>=22.19.0'}
+  '@milaboratories/helpers@1.14.4':
+    resolution: {integrity: sha512-0mS5GQAQYUab0qj1C6+IXafNJhL1ahnhPBmIkLq9VqJU8p9jNZ7KC5ln4/pl0tK47brdPljCLEiLg8IdSa6wFw==}
+    engines: {node: '>=22'}
 
-  '@milaboratories/pf-spec-driver@1.4.18':
-    resolution: {integrity: sha512-lXaoSyGCWUlrYZaoyRIWWT0Hpx9DWODXI7VdraNjYnCofJpYKMdAZW3sfCE9kdVup8ic29vywNPLeTjrVQ24sg==}
+  '@milaboratories/pf-driver@1.8.2':
+    resolution: {integrity: sha512-K5jKzqFfsOJL051U1VAg2Iy9iE01Hwm+FtRb2/PcB0DV3VItIozXRF/mvcXKDHbSCLcPcRGqZjtEF3kMczd+sA==}
+    engines: {node: '>=22.19.0'}
 
   '@milaboratories/pf-spec-driver@1.4.19':
     resolution: {integrity: sha512-dfQIe9qMFuoRRNauG+1suZhuFBHeRmaVBCk+BqnlTs/mMPnKnXsZAmADsFbQYxl2qS5nHDerzhBPBpYa+Ippxg==}
 
-  '@milaboratories/pframes-rs-node@1.1.52':
-    resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
+  '@milaboratories/pf-spec-driver@1.4.21':
+    resolution: {integrity: sha512-JuYVQKs4aia8DA8MVqdImu+Ho+uTwwOqIaJ3VVPMpCMo3QAH9jZP+wGlkklSwow4d+27Y8L2RJN/1dcPr56GZw==}
 
-  '@milaboratories/pframes-rs-serv@1.1.52':
-    resolution: {integrity: sha512-yVfcyLztgj5UAffj30se5G4MwxkIOFVWPHY1tZZ8zLhQQzx95R/e1toAqq3FLV7y6kpJovwmLusbefgKw9Ejcg==}
+  '@milaboratories/pframes-rs-node@1.1.55':
+    resolution: {integrity: sha512-TbudDPMixADLyVr5UsiXhf+zq7YCJA3osFrzDn7Lr5aeyorCjiXDkVOGKpID7GkkssuVsNpPXtoGdA71Y2tLjQ==}
+
+  '@milaboratories/pframes-rs-serv@1.1.55':
+    resolution: {integrity: sha512-cGByUULBA/JiwyFEBZrVNOEbnbrMPWWHCWLprRKlVWlmDMaRmsVft/tFpnle46BhDZWpoWbaKEZ8NGOtGqDCXw==}
     hasBin: true
 
   '@milaboratories/pframes-rs-wasip2@1.1.52':
     resolution: {integrity: sha512-0rb0We6Q/aqrHJ062dayvLb4RExODZdqfsVWdzeHq23alY5TjJRMWsO9aKQpPnOuUKjAimdjlp+Ldq9TVhbEtg==}
+
+  '@milaboratories/pframes-rs-wasip2@1.1.55':
+    resolution: {integrity: sha512-mwKTmcDiuN6Id2h+oxKX2W5igFhMxDvRZs4clsxhPTYZASSROrvsSsaoXS81meqfC0phx+BUaRpdrkVQIKSdxQ==}
 
   '@milaboratories/pframes-rs-wasm@1.1.52':
     resolution: {integrity: sha512-Wn8/LJxcsvWSSpdymdebWrBnmgu9wAbzvOiHCtXz7Aqt1M2T8Xp9a7CprzCYx+EvhSuAuoxbq6naxkPsQrbkvg==}
@@ -947,19 +957,26 @@ packages:
       '@milaboratories/pl-model-common': 1.46.2
       '@milaboratories/pl-model-middle-layer': 1.30.7
 
-  '@milaboratories/pl-client@3.14.1':
-    resolution: {integrity: sha512-nOmpoIKBiiOd81lAlQhdzU1y38woKMF3cZ5wCb51aoPlwcWuTL6TqIbkoB5B4L7KmXkTIhJDIRUKryD3xWVHnw==}
+  '@milaboratories/pframes-rs-wasm@1.1.55':
+    resolution: {integrity: sha512-kVOL+eAasfeiui5lQ5G92nsSiTNSsOnl1m+4my0tmbR7VTCa15dn1kd5RcXS3/8YO5oEcnGlCUhnu5kKMtweEw==}
+    peerDependencies:
+      '@bytecodealliance/preview2-shim': 0.17.9
+      '@milaboratories/pl-model-common': 1.46.2
+      '@milaboratories/pl-model-middle-layer': 1.30.7
+
+  '@milaboratories/pl-client@3.14.2':
+    resolution: {integrity: sha512-+0ih1njQn4wvLjGmFKboKFRlWYLrzg7QdRK2aNo8ivTKY16TrsMRCk0GQEt0aPKELnv7QSrsNSjg7e7GSdGMDQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.8.3':
-    resolution: {integrity: sha512-JPIWG/9q7SL9QSYUhHwF9MCfGbpJyo2KxaO9IE2gEvy+oiGw1oBJvNdthC9V/uW2jHp/Qov9+x7LveHzN+bfeA==}
+  '@milaboratories/pl-config@1.8.4':
+    resolution: {integrity: sha512-eBZCIVhl9jRigyJUPURCxH2f2OrU5aToihSrwmTkCOu2rjr1spe4YGMIh9CxPr8Z1GkfQbez3crJGME1+RZrrg==}
 
-  '@milaboratories/pl-deployments@3.0.11':
-    resolution: {integrity: sha512-4iMjul81OeWMzIOzd1XHqN0y3sxSG88AwNuW8vWzCENA95CXhYNojJJEHKKMXIrNEN3m0hA+PiMk4OGMXTYLEA==}
+  '@milaboratories/pl-deployments@3.0.12':
+    resolution: {integrity: sha512-Oo7MGAwMyC8F5zCZWgs3Q/sET584Ussux8YP6TB+UBfWcNwZVZWbiO/QaRewfjnMfKSJ4Uden7RoQ4hHWvWChA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.16.9':
-    resolution: {integrity: sha512-V2ilbwBkGfRSK1z6hB3LfT/v7y8Jvu3WkKR2TVvW2Yn08WxbSpPgU5m5xXEeUXq6eCNrZRUrvbv/QvvOS402Gg==}
+  '@milaboratories/pl-drivers@1.16.10':
+    resolution: {integrity: sha512-5lrewLkmN9Z6dWkRw2kYbsjquHNSHBni8seTI3BsP9xijuv4NzEkvDcJLJsQsuZcuaFtyw77fHAKvNmlYZiJeA==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
@@ -968,22 +985,22 @@ packages:
   '@milaboratories/pl-error-like@1.12.5':
     resolution: {integrity: sha512-opYP4OrB6JBMsH9RMRmAH44+MG7PWiV08dHW9+RsXGOaqX+rYXs9TTBXYRhlVMDLwwefSKzelvDg8HL748aM+A==}
 
-  '@milaboratories/pl-errors@1.4.30':
-    resolution: {integrity: sha512-wG0yQTMynVfMMf2iQCP/yfLpVJNtyFNXxAEus3ZxrCO1t5IDfdwYaAbWgHgKIzloG0pUFNk11NqHwpE/9F3psg==}
+  '@milaboratories/pl-errors@1.4.31':
+    resolution: {integrity: sha512-XK4npZNtHksD+IHuzsaf4SXtceqRpwCH/PxZy7zijFqNuW5cdl7be8Parr8T+wQzYaDgHLVSKrYilzC56RNx/Q==}
 
-  '@milaboratories/pl-healthcheck@1.0.2':
-    resolution: {integrity: sha512-IBXQOSgJj7T/dw26AXBsR1ZaOpoqxZtSFZVPE2TonT0VaLKH4XqMFa3C+fKV1aECqbI45dBRQl/X70CUdGPWgQ==}
+  '@milaboratories/pl-healthcheck@1.0.3':
+    resolution: {integrity: sha512-krt75tuov2T0TKAsybbSzwHt45JjAQJbnqya0FiRApme913k6DvoowEX2NYLzRChbn+QVbs4ODxJI8lcgFexVg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.66.0':
-    resolution: {integrity: sha512-3eAqVhXELfM6P4VvfNGkTakGOJrZ9EMqrfXMxqUqZbLuikJEiUPc9R1JVUxlsSTvXzmYvsaO+uCDmgL+BlVnJA==}
+  '@milaboratories/pl-middle-layer@1.66.2':
+    resolution: {integrity: sha512-N8nZ9Ch3nxm3b4lIqNRiSJj3FiPXH1O8tJVnNFwMkLcUnzkQnWEnOzrZtZaBIMgwZEK2tl3LKwnvEF9RQ3T5kQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.15':
-    resolution: {integrity: sha512-16ErgMuZu5MJXf7TFdy0Sit91T7cUQ/ixWMIlHqzSIrZwmx4AqKQIhN8dm71gTkb6fS2hMCjf6ok8MexQGWESA==}
+  '@milaboratories/pl-model-backend@1.4.16':
+    resolution: {integrity: sha512-MrJwM3aOzrqr3+GVpS/1Zh/SOH/2tBtoyk/+eE6C7LRjofoip8GIF4be8AgPAM3C+6wTSGrQ5x3CM6A8Ql2HVA==}
 
   '@milaboratories/pl-model-common@1.21.9':
     resolution: {integrity: sha512-0n8oq0e4ZqbMJIzVnP478BGT86vB4gNSRoDic1ai7bNwMiO+jtNSOwGMwR0mFeRLqXidSLcfDxiEMXmak34f7g==}
@@ -991,33 +1008,33 @@ packages:
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
-  '@milaboratories/pl-model-common@1.46.4':
-    resolution: {integrity: sha512-QArgLyQkf8kHSQquxStyk5Xfnau8S4M2vKEbUVQRRoZCzLU1lcDVXRwGgAzRH5NizeqYNrB/wt0/tShajH+6eA==}
-
   '@milaboratories/pl-model-common@1.47.0':
     resolution: {integrity: sha512-HmUwNjiA6jo66NhKrl6SLnAoobLuEqw5kyna7aiMC9H3PH1vRk5Jzbvlx83FjQGXsjCIzqEoJJKWNIMXbb2VEg==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.11':
-    resolution: {integrity: sha512-yFThwVqOTb2gJw/tp4PkZcsKI7yRRJCX3QuA6fIc2+tNxCqyEQmdpLmaIY/nhaziIp9ByBT9MrzWNIQd1T9aww==}
+  '@milaboratories/pl-model-common@1.47.1':
+    resolution: {integrity: sha512-5F9I8JvUPRJ2HEzz5MmTio6JFYnhYoMVHfToh2NyXyOyQgAF6jhOzZBOsrEig9NfCPZBRB7v6UjmIK43dG4o/g==}
 
   '@milaboratories/pl-model-middle-layer@1.30.12':
     resolution: {integrity: sha512-+0c9MQ64fivMjUBwX1jKzafzTDAGSc5jRFAt4qnX7v1ysefotc+BD/ObukVFbafxHu93I4hzf4ERw10xo8KDcw==}
 
+  '@milaboratories/pl-model-middle-layer@1.30.13':
+    resolution: {integrity: sha512-owQVozyub/6aKgk+yce+9sDK+t0HrpLbnlKJqQjYJahuhoju8j6VMY17AWgvADSDCiI3gnp/Tm/I4Ur6ySs1Cg==}
+
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
-  '@milaboratories/pl-tree@1.13.0':
-    resolution: {integrity: sha512-+BssrJGdVWWW9H9v6RNxR5OmHeSsyUKdNrLnDW6rTQr+dywNi/3Gp0eeZJSG89U6oRrolitzhKgC3Re+0tJmbQ==}
+  '@milaboratories/pl-tree@1.13.1':
+    resolution: {integrity: sha512-NtVVUSF9eJA5v5iUEfGgKl0JbG/EIvy+YCsxzCZ1dXG1S3gCNwt01Nj5PkWW7FkDG1IT0ZfwyeO0mVVz2kIv1Q==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/ptabler-expression-js@1.1.5':
     resolution: {integrity: sha512-EBnOKHbXNhR+dGeKvUY84eEdXgZeLrunJdlNpauXWa+mnaCOwF2J1xxjberfeAi36xS90IoeW6Hy7pi9k0TycQ==}
 
-  '@milaboratories/ptabler-expression-js@1.2.33':
-    resolution: {integrity: sha512-ThB7tc0nPACE7b8cSoA0+zRVZfZHOCAcFioFDi207G5prgrIc/z2zbInjD0PRnWFHO7xOsfbWCkNRDqCmut6zQ==}
-
   '@milaboratories/ptabler-expression-js@1.2.34':
     resolution: {integrity: sha512-MOLdW0Ntn92cvdZMhwe09rgAgMf16jJMKKD/DQp1Oq3aZCEZiJ2psj4pmmrGToJ9d17+4fgqD/nXV7VTwvKWgw==}
+
+  '@milaboratories/ptabler-expression-js@1.2.35':
+    resolution: {integrity: sha512-nTVNYgNHuUswPnAe8GFAitbewNVMHaxhAncQ3yMYfGzsGgZupQyGV6K1DHVkzMAwNwVFVLwIbiPMY58en03XWQ==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1037,15 +1054,15 @@ packages:
   '@milaboratories/ts-configs@1.3.0':
     resolution: {integrity: sha512-6rZaMOJotG+v6eXoupHgPqxArpNBNl0f7sd5K+kUo1PUhPTe632eLJtEeBbFtwDGNYqL9QUacd4pT5t6oDOf0A==}
 
-  '@milaboratories/ts-helpers@1.8.4':
-    resolution: {integrity: sha512-YdOyANkJjFiEZgS3bfbludDo9PWOQZQ8AhGw/rpO5/7bgQ9RIVOOTAtP5/UppANoeUiYhCgJt/xvIZgnQ/PZ0w==}
+  '@milaboratories/ts-helpers@1.8.5':
+    resolution: {integrity: sha512-vZDcIBta7I935VjKk6qGdhpjz2pWXe5CbWv1UUmPrcG8wsunDpWuet8/Gi75N97CpcLDc2LLHd/url9K8ZNpAg==}
     engines: {node: '>=22.19.0'}
-
-  '@milaboratories/uikit@2.15.14':
-    resolution: {integrity: sha512-alefttXyF4j1h1riJMJypgalcVSQ1KFHD2P4r6kOe2uPrrI7CjpBrrn6GCqUmLmvRe/mz8eNFvoyiZBo4pe5BQ==}
 
   '@milaboratories/uikit@2.15.15':
     resolution: {integrity: sha512-JCuLoQaysQyvAMj5c0SqLj8Wd1e7UBYN/mzZICDHpDjFDue2Sl/yfHsabWSfRb3VrkkDD9p0z6INWnWZv7JCyg==}
+
+  '@milaboratories/uikit@2.15.16':
+    resolution: {integrity: sha512-HOl1YsPKHpj3izKAs0hEvVtFE8ZbrOnD5KsAqSHxvipQyfAdOLbfB7ak6XPdPKbgsvH5opfMws7usryR6Nlulw==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1387,11 +1404,11 @@ packages:
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.5':
     resolution: {integrity: sha512-8KDVwfi00gqNU8r92XxecVleu/Jk5RoylwOMsoUatbkyTVL/+yQavdAgXc5aRLop07AvG3cFpHXW8ZqYBc7zbQ==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
-    resolution: {integrity: sha512-Qf4QpFY8bWVtEeQphWGZ67dUaXYVWSFm/AL1ErzdOYhilnDSon2Cya6K2Fkj0TxEGBLMBxOudF/kmTw728/Pag==}
-
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.18':
     resolution: {integrity: sha512-u/Z1zUx52NlpS3eCIZF8roEWKMmQkYNVTFiTTUfHH9Jki6YFjl/9yiUu9pGqAADhZ9wX0F3JNW4Q2u4Qkkb2Gw==}
+
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.19':
+    resolution: {integrity: sha512-h/FBLELZT6PJZnWtwvcy8bQrpZ2A6xWSVSjyccqb3QolHSbeuwi5UpUph8UxdDYNmWSCH0zR/zE2hFypgk21xA==}
 
   '@platforma-open/milaboratories.software-ptabler@1.13.5':
     resolution: {integrity: sha512-G45vIsEumTTKg7TquqS6F8aB1ExYMkqhGt64a+8doSdE+U7RnKIU3jl4e++WRrAPlyzki0DuGipQ7umeTlktjA==}
@@ -1399,8 +1416,8 @@ packages:
   '@platforma-open/milaboratories.software-ptabler@1.16.1':
     resolution: {integrity: sha512-m4tzKYlopjHLYpRLSjIqEtFr0QP7MuweaMCTEmr6a+gIVE+x9MKawdXwNwo1A/2QuatygIcGRvIcIz34WibZMA==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.5':
-    resolution: {integrity: sha512-bZgDa+KJyAgKKu/Ka+Hzh7thZU/PkmupMRUvXV1ruLdJoxvIcyOj9ehQuVi5DapX4sE7iQ5EkavqpK59z0oZ8w==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.6':
+    resolution: {integrity: sha512-LdDU9/z+iejw5F98J8DYVQKsjUGGiyu8rHWCjWCEqOVEP+N9QBcN4ibDgG4Xp/GL+IzKxicAkf2Ae9lHollD6w==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.0':
     resolution: {integrity: sha512-7dKhQyecDcxjRNOS9XRgLemZpOuJ3dKMryrBbbkYR6VLKj566tJkbKiC7p1wAWEtHKHEZUhCQYgTZfEtwHCkDA==}
@@ -1468,8 +1485,8 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.12.5':
-    resolution: {integrity: sha512-6LrvNGb818I3JjJXTgF4HORqlfR9bmpzTddtTtD5u/UtjF5My+eSvAgi+jpO3vFrUADGZ5MPDD8S1Ikro8CexA==}
+  '@platforma-sdk/block-tools@2.12.6':
+    resolution: {integrity: sha512-MtsYTCNhCCA9drSihSh5uXUY2/qCNai/ekOX2pw2gtzjHPXPqnin1Wzri0z/2N1wOShXodRItBUglALNJFWUsQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1479,28 +1496,28 @@ packages:
   '@platforma-sdk/model@1.46.0':
     resolution: {integrity: sha512-tY1kad46WKvpGHSPoOXfQ3FuBs62CL7rQLrBlzEhfQRAL96dWbycORbH1oo82vEzW39f7F6Q5kgg14Yx6uL/tQ==}
 
-  '@platforma-sdk/model@1.79.27':
-    resolution: {integrity: sha512-Z5WYpClTZoBtvfGsiDPNlRCxPKtUF04TV3MmL1Kfb6xAb04B5NdiqWMnqw+v78Kue/y9FKTmxrCcX9lwZgYFlw==}
-
   '@platforma-sdk/model@1.80.0':
     resolution: {integrity: sha512-wqn721wKdZCy5FWB8uDZDgKwofQSPCjOHBCv4EaaIRB78URR43cKtKXl+MrUV8BxgqwMa9R8EBv2wfyA48s3bA==}
+
+  '@platforma-sdk/model@1.80.2':
+    resolution: {integrity: sha512-aQGVxjxw7y34U0ZuboIYASodJMZ1yTjXH2y44bCdeTeS/r81YBBmGrF6BQhHHVjIOIhaIlWHRBIhd9AJo42aWQ==}
 
   '@platforma-sdk/package-builder-lib@1.2.0':
     resolution: {integrity: sha512-AtSzaZ39BGlqcyYtpGREDz+YlGCDdSTQJNV/+NkTyUtoq1ECRO+iMqAX1DSSza1WqylnURX8vKVI2owS/cxntA==}
 
-  '@platforma-sdk/tengo-builder@4.0.17':
-    resolution: {integrity: sha512-0VfRAjHtl7TRYUzrVV9F0vbLVA7LgsYNg0njW0wro3b4pIdNK/izDjQRxT9zfgGIcNuo2hyDIAbiKiCGApzdkw==}
+  '@platforma-sdk/tengo-builder@4.0.18':
+    resolution: {integrity: sha512-nGPB5fE6b9ITFuXVMRakr2MyqsnL4TVE09jZ2X7TCPgb31k4gIhYCT+XU9vBRavBj/U3dt+jSWHkcbX9JvJKYA==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.80.0':
-    resolution: {integrity: sha512-ccwHHO5N8mOq0qWKRjj8NFBtCSW5UicoX/kA6VZ5NDhlnCvGLh+O7+Xg7KLLg45FEjVTZJ6i9LQjGgXwBsfvEw==}
-
-  '@platforma-sdk/ui-vue@1.79.34':
-    resolution: {integrity: sha512-n2u4sjtVFh5amrIXiLQ0LA8OlJdtQ+ZMAr8aqSacxfHkBSUR1my5TVOSxfZ6xA8Huief2T4ERsEeJAqyLS7v+w==}
+  '@platforma-sdk/test@1.80.2':
+    resolution: {integrity: sha512-tEdcYLl4lp5ywXse5YMpCGxekGyVS4ZMmiMijsJ6lBDpBHJEm8bDioRXQyBbc2Cg3RKnVPjZZxOny+48n4RdPw==}
 
   '@platforma-sdk/ui-vue@1.80.0':
     resolution: {integrity: sha512-NWhWcnxMOxnMqqFaDNdqQnjzo+0xqGpjS5WrKlgtrEjFR71aRDfie0AQk+lBAQ+kOpYBpyRpcZM3Et4zjloupg==}
+
+  '@platforma-sdk/ui-vue@1.80.2':
+    resolution: {integrity: sha512-aTvUEpwgHv/bul8W/h2tLgmZfrapnNV5SkDjVEFSe+jh9B9I40hxNPrporltAcShq9xqa9DhxP8/HctnzfnKdA==}
 
   '@platforma-sdk/workflow-tengo@5.24.0':
     resolution: {integrity: sha512-LFZbnHHU3yBulorph6867ZF0P8mtm0scEXQxplNJXxylMJp09uHSCKp/1JHhsMK7v8/iEY0Tph7RgVJXVSwmoA==}
@@ -1508,8 +1525,8 @@ packages:
   '@platforma-sdk/workflow-tengo@5.6.3':
     resolution: {integrity: sha512-yRRCk6rivpBncX6kXg/6qVWCqQos9aU+30uXN4Ndt5UwEHc5rtNowvZzb5R8wMbIOlHONbp1azJkw1k9tvKbVg==}
 
-  '@platforma-sdk/workflow-tengo@6.7.1':
-    resolution: {integrity: sha512-8vAXzDzDZpHncMHSuTjesuD/tOWWRhWyQIr8jH2MBgWJGkUXUtoDLBqYk6l5knHrYfrorDzXjsnsFQCzU0bI1A==}
+  '@platforma-sdk/workflow-tengo@6.7.2':
+    resolution: {integrity: sha512-KJ4tBigEDN+EIDy7K2u7PqxBIDrhwvnazJthApGg2N/HPZkinKmq0iMzHC9KZ0IsJVg6uxECIB2d2Acko33tOw==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -5697,10 +5714,15 @@ snapshots:
       '@milaboratories/helpers': 1.14.3
       '@milaboratories/pl-model-common': 1.47.0
 
-  '@milaboratories/computable@2.9.6':
+  '@milaboratories/columns-collection-driver@0.2.1':
+    dependencies:
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pl-model-common': 1.47.1
+
+  '@milaboratories/computable@2.9.7':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
@@ -5708,30 +5730,22 @@ snapshots:
 
   '@milaboratories/helpers@1.14.3': {}
 
-  '@milaboratories/pf-driver@1.8.0(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/helpers@1.14.4': {}
+
+  '@milaboratories/pf-driver@1.8.2(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/pl-model-middle-layer': 1.30.12
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pframes-rs-node': 1.1.55
+      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@milaboratories/ts-helpers': 1.8.5
       es-toolkit: 1.41.0
       lru-cache: 11.2.2
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - encoding
       - supports-color
-
-  '@milaboratories/pf-spec-driver@1.4.18(@bytecodealliance/preview2-shim@0.17.8)':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
-      '@noble/hashes': 2.0.1
-    transitivePeerDependencies:
-      - '@bytecodealliance/preview2-shim'
 
   '@milaboratories/pf-spec-driver@1.4.19(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
@@ -5743,18 +5757,28 @@ snapshots:
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.52':
+  '@milaboratories/pf-spec-driver@1.4.21(@bytecodealliance/preview2-shim@0.17.8)':
+    dependencies:
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@noble/hashes': 2.0.1
+    transitivePeerDependencies:
+      - '@bytecodealliance/preview2-shim'
+
+  '@milaboratories/pframes-rs-node@1.1.55':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.52
+      '@milaboratories/pframes-rs-serv': 1.1.55
       '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.52':
+  '@milaboratories/pframes-rs-serv@1.1.55':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
@@ -5765,12 +5789,7 @@ snapshots:
 
   '@milaboratories/pframes-rs-wasip2@1.1.52': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)':
-    dependencies:
-      '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
+  '@milaboratories/pframes-rs-wasip2@1.1.55': {}
 
   '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)':
     dependencies:
@@ -5779,12 +5798,19 @@ snapshots:
       '@milaboratories/pl-model-common': 1.47.0
       '@milaboratories/pl-model-middle-layer': 1.30.12
 
-  '@milaboratories/pl-client@3.14.1':
+  '@milaboratories/pframes-rs-wasm@1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)':
+    dependencies:
+      '@bytecodealliance/preview2-shim': 0.17.8
+      '@milaboratories/pframes-rs-wasip2': 1.1.55
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
+
+  '@milaboratories/pl-client@3.14.2':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/ts-helpers': 1.8.5
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -5797,19 +5823,19 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.1
 
-  '@milaboratories/pl-config@1.8.3':
+  '@milaboratories/pl-config@1.8.4':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       upath: 2.0.1
       yaml: 2.8.1
 
-  '@milaboratories/pl-deployments@3.0.11':
+  '@milaboratories/pl-deployments@3.0.12':
     dependencies:
-      '@milaboratories/pl-config': 1.8.3
-      '@milaboratories/pl-healthcheck': 1.0.2
+      '@milaboratories/pl-config': 1.8.4
+      '@milaboratories/pl-healthcheck': 1.0.3
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/ts-helpers': 1.8.5
       decompress: 4.2.1
       ssh2: 1.16.0
       tar: 7.4.3
@@ -5818,15 +5844,15 @@ snapshots:
       yaml: 2.8.1
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.16.9':
+  '@milaboratories/pl-drivers@1.16.10':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-client': 3.14.1
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/pl-tree': 1.13.0
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-tree': 1.13.1
+      '@milaboratories/ts-helpers': 1.8.5
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
@@ -5853,16 +5879,16 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-errors@1.4.30':
+  '@milaboratories/pl-errors@1.4.31':
     dependencies:
-      '@milaboratories/pl-client': 3.14.1
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/ts-helpers': 1.8.5
       zod: 3.25.76
 
-  '@milaboratories/pl-healthcheck@1.0.2':
+  '@milaboratories/pl-healthcheck@1.0.3':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -5871,29 +5897,29 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.66.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.66.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
-      '@milaboratories/columns-collection-driver': 0.2.0
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pf-driver': 1.8.0(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.4.19(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)
-      '@milaboratories/pl-client': 3.14.1
-      '@milaboratories/pl-deployments': 3.0.11
-      '@milaboratories/pl-drivers': 1.16.9
-      '@milaboratories/pl-errors': 1.4.30
+      '@milaboratories/columns-collection-driver': 0.2.1
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pf-driver': 1.8.2(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.21(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pframes-rs-node': 1.1.55
+      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-deployments': 3.0.12
+      '@milaboratories/pl-drivers': 1.16.10
+      '@milaboratories/pl-errors': 1.4.31
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.15
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/pl-model-middle-layer': 1.30.12
-      '@milaboratories/pl-tree': 1.13.0
+      '@milaboratories/pl-model-backend': 1.4.16
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@milaboratories/pl-tree': 1.13.1
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.4
-      '@platforma-sdk/block-tools': 2.12.5(@types/node@24.5.2)
-      '@platforma-sdk/model': 1.80.0
-      '@platforma-sdk/workflow-tengo': 6.7.1
+      '@milaboratories/ts-helpers': 1.8.5
+      '@platforma-sdk/block-tools': 2.12.6(@types/node@24.5.2)
+      '@platforma-sdk/model': 1.80.2
+      '@platforma-sdk/workflow-tengo': 6.7.2
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.41.0
@@ -5912,9 +5938,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.15':
+  '@milaboratories/pl-model-backend@1.4.16':
     dependencies:
-      '@milaboratories/pl-client': 3.14.1
+      '@milaboratories/pl-client': 3.14.2
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -5931,13 +5957,6 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.46.4':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-error-like': 1.12.10
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
   '@milaboratories/pl-model-common@1.47.0':
     dependencies:
       '@milaboratories/helpers': 1.14.3
@@ -5946,18 +5965,26 @@ snapshots:
       es-toolkit: 1.41.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.11':
+  '@milaboratories/pl-model-common@1.47.1':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pl-error-like': 1.12.10
+      canonicalize: 2.1.0
       es-toolkit: 1.41.0
-      utility-types: 3.11.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.30.12':
     dependencies:
       '@milaboratories/helpers': 1.14.3
       '@milaboratories/pl-model-common': 1.47.0
+      es-toolkit: 1.41.0
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.30.13':
+    dependencies:
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pl-model-common': 1.47.1
       es-toolkit: 1.41.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -5970,12 +5997,12 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.13.0':
+  '@milaboratories/pl-tree@1.13.1':
     dependencies:
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/pl-client': 3.14.1
-      '@milaboratories/pl-errors': 1.4.30
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-errors': 1.4.31
+      '@milaboratories/ts-helpers': 1.8.5
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -5984,13 +6011,13 @@ snapshots:
     dependencies:
       '@platforma-open/milaboratories.software-ptabler.schema': 1.12.5
 
-  '@milaboratories/ptabler-expression-js@1.2.33':
-    dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.17
-
   '@milaboratories/ptabler-expression-js@1.2.34':
     dependencies:
       '@platforma-open/milaboratories.software-ptabler.schema': 1.15.18
+
+  '@milaboratories/ptabler-expression-js@1.2.35':
+    dependencies:
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.19
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -6123,16 +6150,16 @@ snapshots:
 
   '@milaboratories/ts-configs@1.3.0': {}
 
-  '@milaboratories/ts-helpers@1.8.4':
+  '@milaboratories/ts-helpers@1.8.5':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/helpers': 1.14.4
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.14(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.15(typescript@5.9.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.3
-      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/model': 1.80.0
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -6163,10 +6190,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@milaboratories/uikit@2.15.15(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.16(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@platforma-sdk/model': 1.80.0
+      '@milaboratories/helpers': 1.14.4
+      '@platforma-sdk/model': 1.80.2
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -6442,15 +6469,15 @@ snapshots:
 
   '@platforma-open/milaboratories.mixcr-clonotyping-2.model@1.20.0':
     dependencies:
-      '@platforma-sdk/model': 1.80.0
+      '@platforma-sdk/model': 1.80.2
       zod: 3.23.8
 
   '@platforma-open/milaboratories.mixcr-clonotyping-2.ui@1.19.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.3
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model': 1.20.0
-      '@platforma-sdk/model': 1.80.0
-      '@platforma-sdk/ui-vue': 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@platforma-sdk/model': 1.80.2
+      '@platforma-sdk/ui-vue': 1.80.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@vueuse/core': 13.9.0(vue@3.5.25(typescript@5.9.3))
       ag-grid-enterprise: 34.1.2
       ag-grid-vue3: 34.1.2(vue@3.5.25(typescript@5.9.3))
@@ -6482,7 +6509,7 @@ snapshots:
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model': 1.20.0
       '@platforma-open/milaboratories.mixcr-clonotyping-2.ui': 1.19.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@platforma-open/milaboratories.mixcr-clonotyping-2.workflow': 3.17.1
-      '@platforma-sdk/model': 1.80.0
+      '@platforma-sdk/model': 1.80.2
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - async-validator
@@ -6530,19 +6557,19 @@ snapshots:
     dependencies:
       '@milaboratories/pl-model-common': 1.21.9
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
-    dependencies:
-      '@milaboratories/pl-model-common': 1.46.4
-
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.18':
     dependencies:
       '@milaboratories/pl-model-common': 1.47.0
+
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.19':
+    dependencies:
+      '@milaboratories/pl-model-common': 1.47.1
 
   '@platforma-open/milaboratories.software-ptabler@1.13.5': {}
 
   '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.5': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.6': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.0': {}
 
@@ -6607,17 +6634,17 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.12.5(@types/node@24.5.2)':
+  '@platforma-sdk/block-tools@2.12.6(@types/node@24.5.2)':
     dependencies:
       '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.15
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/pl-model-middle-layer': 1.30.12
+      '@milaboratories/pl-model-backend': 1.4.16
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       '@platforma-sdk/blocks-deps-updater': 2.2.0
       '@platforma-sdk/package-builder-lib': 1.2.0
       canonicalize: 2.1.0
@@ -6646,19 +6673,6 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@platforma-sdk/model@1.79.27':
-    dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
-      '@milaboratories/ptabler-expression-js': 1.2.33
-      canonicalize: 2.1.0
-      es-toolkit: 1.41.0
-      fast-json-patch: 3.1.1
-      utility-types: 3.11.0
-      zod: 3.25.76
-
   '@platforma-sdk/model@1.80.0':
     dependencies:
       '@milaboratories/helpers': 1.14.3
@@ -6666,6 +6680,20 @@ snapshots:
       '@milaboratories/pl-model-common': 1.47.0
       '@milaboratories/pl-model-middle-layer': 1.30.12
       '@milaboratories/ptabler-expression-js': 1.2.34
+      canonicalize: 2.1.0
+      es-toolkit: 1.41.0
+      fast-json-patch: 3.1.1
+      lru-cache: 11.2.2
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@platforma-sdk/model@1.80.2':
+    dependencies:
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pl-error-like': 1.12.10
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@milaboratories/ptabler-expression-js': 1.2.35
       canonicalize: 2.1.0
       es-toolkit: 1.41.0
       fast-json-patch: 3.1.1
@@ -6686,22 +6714,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@4.0.17':
+  '@platforma-sdk/tengo-builder@4.0.18':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.4.15
+      '@milaboratories/pl-model-backend': 1.4.16
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       commander: 15.0.0
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.80.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.80.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
     dependencies:
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/pl-client': 3.14.1
-      '@milaboratories/pl-middle-layer': 1.66.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
-      '@milaboratories/pl-tree': 1.13.0
-      '@platforma-sdk/model': 1.80.0
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-middle-layer': 1.66.2(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-tree': 1.13.1
+      '@platforma-sdk/model': 1.80.2
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
       vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -6723,12 +6751,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.80.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/uikit': 2.15.14(typescript@5.9.3)
-      '@platforma-sdk/model': 1.79.27
+      '@milaboratories/columns-collection-driver': 0.2.0
+      '@milaboratories/pf-spec-driver': 1.4.19(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/uikit': 2.15.15(typescript@5.9.3)
+      '@platforma-sdk/model': 1.80.0
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -6759,13 +6788,13 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/ui-vue@1.80.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.80.2(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/columns-collection-driver': 0.2.0
-      '@milaboratories/pf-spec-driver': 1.4.19(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.47.0
-      '@milaboratories/uikit': 2.15.15(typescript@5.9.3)
-      '@platforma-sdk/model': 1.80.0
+      '@milaboratories/columns-collection-driver': 0.2.1
+      '@milaboratories/pf-spec-driver': 1.4.21(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/uikit': 2.15.16(typescript@5.9.3)
+      '@platforma-sdk/model': 1.80.2
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -6810,11 +6839,11 @@ snapshots:
       '@platforma-open/milaboratories.software-ptexter': 1.2.0
       '@platforma-open/milaboratories.software-small-binaries': 1.15.26
 
-  '@platforma-sdk/workflow-tengo@6.7.1':
+  '@platforma-sdk/workflow-tengo@6.7.2':
     dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
+      '@milaboratories/pframes-rs-wasip2': 1.1.55
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.5
+      '@platforma-open/milaboratories.software-ptabler': 2.1.6
       '@platforma-open/milaboratories.software-ptexter': 1.2.3
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: 1.14.3
       version: 1.14.3
     '@milaboratories/pl-model-common':
-      specifier: 1.45.0
-      version: 1.45.0
+      specifier: 1.47.0
+      version: 1.47.0
     '@milaboratories/ts-builder':
       specifier: 1.6.0
       version: 1.6.0
@@ -28,20 +28,20 @@ catalogs:
       specifier: ^1.2.3
       version: 1.2.3
     '@platforma-sdk/block-tools':
-      specifier: 2.12.4
-      version: 2.12.4
+      specifier: 2.12.5
+      version: 2.12.5
     '@platforma-sdk/model':
-      specifier: 1.79.27
-      version: 1.79.27
+      specifier: 1.80.0
+      version: 1.80.0
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.16
-      version: 4.0.16
+      specifier: 4.0.17
+      version: 4.0.17
     '@platforma-sdk/test':
-      specifier: 1.79.34
-      version: 1.79.34
+      specifier: 1.80.0
+      version: 1.80.0
     '@platforma-sdk/ui-vue':
-      specifier: 1.79.34
-      version: 1.79.34
+      specifier: 1.80.0
+      version: 1.80.0
     '@platforma-sdk/workflow-tengo':
       specifier: 6.7.1
       version: 6.7.1
@@ -98,7 +98,7 @@ importers:
         version: 1.6.0(@types/node@24.5.2)(rollup@4.46.2)(sass-embedded@1.89.2)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.4(@types/node@24.5.2)
+        version: 2.12.5(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -128,10 +128,10 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.4(@types/node@24.5.2)
+        version: 2.12.5(@types/node@24.5.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.27
+        version: 1.80.0
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -146,7 +146,7 @@ importers:
         version: 1.14.3
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.27
+        version: 1.80.0
       '@types/lodash.omit':
         specifier: ^4.5.9
         version: 4.5.9
@@ -168,7 +168,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.4(@types/node@24.5.2)
+        version: 2.12.5(@types/node@24.5.2)
 
   test:
     dependencies:
@@ -189,7 +189,7 @@ importers:
         version: 2.4.1
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.27
+        version: 1.80.0
       this-block:
         specifier: workspace:@platforma-open/milaboratories.clonotype-browser-3@*
         version: link:../block
@@ -205,7 +205,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.80.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
@@ -214,16 +214,16 @@ importers:
     dependencies:
       '@milaboratories/pl-model-common':
         specifier: 'catalog:'
-        version: 1.45.0
+        version: 1.47.0
       '@platforma-open/milaboratories.clonotype-browser-3.model':
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.27
+        version: 1.80.0
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+        version: 1.80.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -276,10 +276,10 @@ importers:
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.16
+        version: 4.0.17
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.80.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -905,6 +905,9 @@ packages:
   '@milaboratories/build-configs@2.0.0':
     resolution: {integrity: sha512-oec/O8ltsDkP+tbaLXuWZUHg7vW3/e60R4gMLvKF5f9wqXSU/CDe08zG4bUpxEW8xjYQzTyZBOC2iN6cTwNxEA==}
 
+  '@milaboratories/columns-collection-driver@0.2.0':
+    resolution: {integrity: sha512-3u4g//TnDrMSh7j6YTUI7sK5b7pMEDTu5TfwxP3ANn7bGkalkI2+++iskbG461rSwXv5HK9zy7hVuMIuffqj/Q==}
+
   '@milaboratories/computable@2.9.6':
     resolution: {integrity: sha512-Au+84jboSJMM2k39mWUFCtPl2wkislD1fLbb45du1PcAg1GSER1ThSLoBpZUQC2oiTt804WmbzhZ2yaoVZiVLQ==}
     engines: {node: '>=22.19.0'}
@@ -917,12 +920,15 @@ packages:
     resolution: {integrity: sha512-nZv+n+orVzA/GimDTNj6Yjb52+Wu5f/Kf2z6UCGXni6KTquLBfQhi3AFB1mLE7hkUYPvKU6LxuRY02CQMQiTVA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pf-driver@1.7.16':
-    resolution: {integrity: sha512-yujIUylT11CwM4alKVETxTnXQpcKHH1x5hZIAKTni/Q98JHs+teewNhUwpaWACwjuEhmF3EYSTgTXeUoeI9hAg==}
+  '@milaboratories/pf-driver@1.8.0':
+    resolution: {integrity: sha512-fosgbyM72hySHW5gkPN2HHSTSVFaiLo2CF75bDiQ/6KKCuJMUnP9kxcxMIULz/ujS4xQGoBGzZdlbdnKRoZAqA==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pf-spec-driver@1.4.18':
     resolution: {integrity: sha512-lXaoSyGCWUlrYZaoyRIWWT0Hpx9DWODXI7VdraNjYnCofJpYKMdAZW3sfCE9kdVup8ic29vywNPLeTjrVQ24sg==}
+
+  '@milaboratories/pf-spec-driver@1.4.19':
+    resolution: {integrity: sha512-dfQIe9qMFuoRRNauG+1suZhuFBHeRmaVBCk+BqnlTs/mMPnKnXsZAmADsFbQYxl2qS5nHDerzhBPBpYa+Ippxg==}
 
   '@milaboratories/pframes-rs-node@1.1.52':
     resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
@@ -941,19 +947,19 @@ packages:
       '@milaboratories/pl-model-common': 1.46.2
       '@milaboratories/pl-model-middle-layer': 1.30.7
 
-  '@milaboratories/pl-client@3.14.0':
-    resolution: {integrity: sha512-WpKN8u71VAIJ6uYAdZqNe3/Ob73noxw7GW8JFZoIMqGVLwvTAbVyffjKuuH4V9S/hA+OXpv7/Dfxqpph5eAVYg==}
+  '@milaboratories/pl-client@3.14.1':
+    resolution: {integrity: sha512-nOmpoIKBiiOd81lAlQhdzU1y38woKMF3cZ5wCb51aoPlwcWuTL6TqIbkoB5B4L7KmXkTIhJDIRUKryD3xWVHnw==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-config@1.8.3':
     resolution: {integrity: sha512-JPIWG/9q7SL9QSYUhHwF9MCfGbpJyo2KxaO9IE2gEvy+oiGw1oBJvNdthC9V/uW2jHp/Qov9+x7LveHzN+bfeA==}
 
-  '@milaboratories/pl-deployments@3.0.10':
-    resolution: {integrity: sha512-AEFI5gRH1quEUZPqV4wkYabVevpTRGMJXPILsYGh/In9eSw56aHIl8pHoZP5h8v3J5v//KNU7aP8sYANh8S7rA==}
+  '@milaboratories/pl-deployments@3.0.11':
+    resolution: {integrity: sha512-4iMjul81OeWMzIOzd1XHqN0y3sxSG88AwNuW8vWzCENA95CXhYNojJJEHKKMXIrNEN3m0hA+PiMk4OGMXTYLEA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.16.8':
-    resolution: {integrity: sha512-w8K++36KQZkDIkVz5Wk/TXBT8h+KG99eMpWjo3Esq9tK+8v9ZiswTBNuG99Wtg3vdBAaJfqf4iqeblSwZk8QcQ==}
+  '@milaboratories/pl-drivers@1.16.9':
+    resolution: {integrity: sha512-V2ilbwBkGfRSK1z6hB3LfT/v7y8Jvu3WkKR2TVvW2Yn08WxbSpPgU5m5xXEeUXq6eCNrZRUrvbv/QvvOS402Gg==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
@@ -962,8 +968,8 @@ packages:
   '@milaboratories/pl-error-like@1.12.5':
     resolution: {integrity: sha512-opYP4OrB6JBMsH9RMRmAH44+MG7PWiV08dHW9+RsXGOaqX+rYXs9TTBXYRhlVMDLwwefSKzelvDg8HL748aM+A==}
 
-  '@milaboratories/pl-errors@1.4.29':
-    resolution: {integrity: sha512-j1iyOgoUlyk4/HvfhRfzvYRxkN4p01XjmFtdlTu8YdRQRp7goNZXtzTOMFAvltocb+ZeRjEOxIW5+3dsbXsFmA==}
+  '@milaboratories/pl-errors@1.4.30':
+    resolution: {integrity: sha512-wG0yQTMynVfMMf2iQCP/yfLpVJNtyFNXxAEus3ZxrCO1t5IDfdwYaAbWgHgKIzloG0pUFNk11NqHwpE/9F3psg==}
 
   '@milaboratories/pl-healthcheck@1.0.2':
     resolution: {integrity: sha512-IBXQOSgJj7T/dw26AXBsR1ZaOpoqxZtSFZVPE2TonT0VaLKH4XqMFa3C+fKV1aECqbI45dBRQl/X70CUdGPWgQ==}
@@ -972,18 +978,15 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.65.9':
-    resolution: {integrity: sha512-ICbmXZRskk2RSRqthxtBzzkS1Jyc8ccUAHoxV3BplbCtzOS9M+QcebPFg+pCRE6cEDJG+DlMCTOUNL4k6MX5HQ==}
+  '@milaboratories/pl-middle-layer@1.66.0':
+    resolution: {integrity: sha512-3eAqVhXELfM6P4VvfNGkTakGOJrZ9EMqrfXMxqUqZbLuikJEiUPc9R1JVUxlsSTvXzmYvsaO+uCDmgL+BlVnJA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.14':
-    resolution: {integrity: sha512-8hn28/D59y3914PJXaOX2B5HBOYplaBhyvKPhsOjlAUhNATa9QBMMqVmYW5ZUJ8m8zZJJvOUVS8FShBMQQbjFA==}
+  '@milaboratories/pl-model-backend@1.4.15':
+    resolution: {integrity: sha512-16ErgMuZu5MJXf7TFdy0Sit91T7cUQ/ixWMIlHqzSIrZwmx4AqKQIhN8dm71gTkb6fS2hMCjf6ok8MexQGWESA==}
 
   '@milaboratories/pl-model-common@1.21.9':
     resolution: {integrity: sha512-0n8oq0e4ZqbMJIzVnP478BGT86vB4gNSRoDic1ai7bNwMiO+jtNSOwGMwR0mFeRLqXidSLcfDxiEMXmak34f7g==}
-
-  '@milaboratories/pl-model-common@1.45.0':
-    resolution: {integrity: sha512-T3yCPY112J/+b5OjK2qVaJ/sk5rdyA8GNa87YojwZmO9P8KAgngOZrnjmBTnyW3Z64iK4N6Lt64+c0AnPB9sig==}
 
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
@@ -991,14 +994,20 @@ packages:
   '@milaboratories/pl-model-common@1.46.4':
     resolution: {integrity: sha512-QArgLyQkf8kHSQquxStyk5Xfnau8S4M2vKEbUVQRRoZCzLU1lcDVXRwGgAzRH5NizeqYNrB/wt0/tShajH+6eA==}
 
+  '@milaboratories/pl-model-common@1.47.0':
+    resolution: {integrity: sha512-HmUwNjiA6jo66NhKrl6SLnAoobLuEqw5kyna7aiMC9H3PH1vRk5Jzbvlx83FjQGXsjCIzqEoJJKWNIMXbb2VEg==}
+
   '@milaboratories/pl-model-middle-layer@1.30.11':
     resolution: {integrity: sha512-yFThwVqOTb2gJw/tp4PkZcsKI7yRRJCX3QuA6fIc2+tNxCqyEQmdpLmaIY/nhaziIp9ByBT9MrzWNIQd1T9aww==}
+
+  '@milaboratories/pl-model-middle-layer@1.30.12':
+    resolution: {integrity: sha512-+0c9MQ64fivMjUBwX1jKzafzTDAGSc5jRFAt4qnX7v1ysefotc+BD/ObukVFbafxHu93I4hzf4ERw10xo8KDcw==}
 
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
-  '@milaboratories/pl-tree@1.12.19':
-    resolution: {integrity: sha512-Mod4gxBFgpBrLYqB6qIhUolQRrU+PvPgpj2auP3G6KF6GExy2GkZkJ3XX4fKd3sXLWsBim3ISidmA7YWp3Zezw==}
+  '@milaboratories/pl-tree@1.13.0':
+    resolution: {integrity: sha512-+BssrJGdVWWW9H9v6RNxR5OmHeSsyUKdNrLnDW6rTQr+dywNi/3Gp0eeZJSG89U6oRrolitzhKgC3Re+0tJmbQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/ptabler-expression-js@1.1.5':
@@ -1006,6 +1015,9 @@ packages:
 
   '@milaboratories/ptabler-expression-js@1.2.33':
     resolution: {integrity: sha512-ThB7tc0nPACE7b8cSoA0+zRVZfZHOCAcFioFDi207G5prgrIc/z2zbInjD0PRnWFHO7xOsfbWCkNRDqCmut6zQ==}
+
+  '@milaboratories/ptabler-expression-js@1.2.34':
+    resolution: {integrity: sha512-MOLdW0Ntn92cvdZMhwe09rgAgMf16jJMKKD/DQp1Oq3aZCEZiJ2psj4pmmrGToJ9d17+4fgqD/nXV7VTwvKWgw==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1029,11 +1041,11 @@ packages:
     resolution: {integrity: sha512-YdOyANkJjFiEZgS3bfbludDo9PWOQZQ8AhGw/rpO5/7bgQ9RIVOOTAtP5/UppANoeUiYhCgJt/xvIZgnQ/PZ0w==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.13':
-    resolution: {integrity: sha512-IdPV9xuwULSx0zXc006dzfOatJBHJ39TmsBnkdsQ235Jz+c++Klpp8tBvDjeXO10nv0xQiIRTXvDCeXebrRTOg==}
-
   '@milaboratories/uikit@2.15.14':
     resolution: {integrity: sha512-alefttXyF4j1h1riJMJypgalcVSQ1KFHD2P4r6kOe2uPrrI7CjpBrrn6GCqUmLmvRe/mz8eNFvoyiZBo4pe5BQ==}
+
+  '@milaboratories/uikit@2.15.15':
+    resolution: {integrity: sha512-JCuLoQaysQyvAMj5c0SqLj8Wd1e7UBYN/mzZICDHpDjFDue2Sl/yfHsabWSfRb3VrkkDD9p0z6INWnWZv7JCyg==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1378,6 +1390,9 @@ packages:
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
     resolution: {integrity: sha512-Qf4QpFY8bWVtEeQphWGZ67dUaXYVWSFm/AL1ErzdOYhilnDSon2Cya6K2Fkj0TxEGBLMBxOudF/kmTw728/Pag==}
 
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.18':
+    resolution: {integrity: sha512-u/Z1zUx52NlpS3eCIZF8roEWKMmQkYNVTFiTTUfHH9Jki6YFjl/9yiUu9pGqAADhZ9wX0F3JNW4Q2u4Qkkb2Gw==}
+
   '@platforma-open/milaboratories.software-ptabler@1.13.5':
     resolution: {integrity: sha512-G45vIsEumTTKg7TquqS6F8aB1ExYMkqhGt64a+8doSdE+U7RnKIU3jl4e++WRrAPlyzki0DuGipQ7umeTlktjA==}
 
@@ -1453,8 +1468,8 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.12.4':
-    resolution: {integrity: sha512-qIXBByWh/UjSm26GzU0pHldS3/tkT84ijsWKROT7Zq3zFbdJ/7AFCxduqReC51/+z/kLsrvjyhJUNvLozBye0A==}
+  '@platforma-sdk/block-tools@2.12.5':
+    resolution: {integrity: sha512-6LrvNGb818I3JjJXTgF4HORqlfR9bmpzTddtTtD5u/UtjF5My+eSvAgi+jpO3vFrUADGZ5MPDD8S1Ikro8CexA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1467,22 +1482,25 @@ packages:
   '@platforma-sdk/model@1.79.27':
     resolution: {integrity: sha512-Z5WYpClTZoBtvfGsiDPNlRCxPKtUF04TV3MmL1Kfb6xAb04B5NdiqWMnqw+v78Kue/y9FKTmxrCcX9lwZgYFlw==}
 
+  '@platforma-sdk/model@1.80.0':
+    resolution: {integrity: sha512-wqn721wKdZCy5FWB8uDZDgKwofQSPCjOHBCv4EaaIRB78URR43cKtKXl+MrUV8BxgqwMa9R8EBv2wfyA48s3bA==}
+
   '@platforma-sdk/package-builder-lib@1.2.0':
     resolution: {integrity: sha512-AtSzaZ39BGlqcyYtpGREDz+YlGCDdSTQJNV/+NkTyUtoq1ECRO+iMqAX1DSSza1WqylnURX8vKVI2owS/cxntA==}
 
-  '@platforma-sdk/tengo-builder@4.0.16':
-    resolution: {integrity: sha512-08z5kIB5ZnSmvMPu3rcyGxh+yKyQ6fn6tYzq37kK+iLpXrB23fjgOAjqIF6NEq/Dkxr2dWSUa4BXa8XPBc0+SQ==}
+  '@platforma-sdk/tengo-builder@4.0.17':
+    resolution: {integrity: sha512-0VfRAjHtl7TRYUzrVV9F0vbLVA7LgsYNg0njW0wro3b4pIdNK/izDjQRxT9zfgGIcNuo2hyDIAbiKiCGApzdkw==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.34':
-    resolution: {integrity: sha512-Vo+krqfnpnI2IE3Nkbc8HOYGSqf/tp/mbuPCj/6V02WB6/LzyXWsjfp4ZbTkt+75UqSm3blNfeyi8piNg6QWJA==}
-
-  '@platforma-sdk/ui-vue@1.79.27':
-    resolution: {integrity: sha512-L88b8A42n4GRGqMHY4n5o+ROwxPBFSgnwr7axjb1k/zfvKRsawz5urxQ8IEPGQW/41UhxNImIiDmdOD17vHtJQ==}
+  '@platforma-sdk/test@1.80.0':
+    resolution: {integrity: sha512-ccwHHO5N8mOq0qWKRjj8NFBtCSW5UicoX/kA6VZ5NDhlnCvGLh+O7+Xg7KLLg45FEjVTZJ6i9LQjGgXwBsfvEw==}
 
   '@platforma-sdk/ui-vue@1.79.34':
     resolution: {integrity: sha512-n2u4sjtVFh5amrIXiLQ0LA8OlJdtQ+ZMAr8aqSacxfHkBSUR1my5TVOSxfZ6xA8Huief2T4ERsEeJAqyLS7v+w==}
+
+  '@platforma-sdk/ui-vue@1.80.0':
+    resolution: {integrity: sha512-NWhWcnxMOxnMqqFaDNdqQnjzo+0xqGpjS5WrKlgtrEjFR71aRDfie0AQk+lBAQ+kOpYBpyRpcZM3Et4zjloupg==}
 
   '@platforma-sdk/workflow-tengo@5.24.0':
     resolution: {integrity: sha512-LFZbnHHU3yBulorph6867ZF0P8mtm0scEXQxplNJXxylMJp09uHSCKp/1JHhsMK7v8/iEY0Tph7RgVJXVSwmoA==}
@@ -5674,6 +5692,11 @@ snapshots:
 
   '@milaboratories/build-configs@2.0.0': {}
 
+  '@milaboratories/columns-collection-driver@0.2.0':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-model-common': 1.47.0
+
   '@milaboratories/computable@2.9.6':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
@@ -5685,13 +5708,13 @@ snapshots:
 
   '@milaboratories/helpers@1.14.3': {}
 
-  '@milaboratories/pf-driver@1.7.16(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.8.0(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.3
       '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/pl-model-middle-layer': 1.30.12
       '@milaboratories/ts-helpers': 1.8.4
       es-toolkit: 1.41.0
       lru-cache: 11.2.2
@@ -5706,6 +5729,16 @@ snapshots:
       '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
       '@milaboratories/pl-model-common': 1.46.4
       '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@noble/hashes': 2.0.1
+    transitivePeerDependencies:
+      - '@bytecodealliance/preview2-shim'
+
+  '@milaboratories/pf-spec-driver@1.4.19(@bytecodealliance/preview2-shim@0.17.8)':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/pl-model-middle-layer': 1.30.12
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -5739,11 +5772,18 @@ snapshots:
       '@milaboratories/pl-model-common': 1.46.4
       '@milaboratories/pl-model-middle-layer': 1.30.11
 
-  '@milaboratories/pl-client@3.14.0':
+  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)':
+    dependencies:
+      '@bytecodealliance/preview2-shim': 0.17.8
+      '@milaboratories/pframes-rs-wasip2': 1.1.52
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/pl-model-middle-layer': 1.30.12
+
+  '@milaboratories/pl-client@3.14.1':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-common': 1.47.0
       '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
@@ -5763,12 +5803,12 @@ snapshots:
       upath: 2.0.1
       yaml: 2.8.1
 
-  '@milaboratories/pl-deployments@3.0.10':
+  '@milaboratories/pl-deployments@3.0.11':
     dependencies:
       '@milaboratories/pl-config': 1.8.3
       '@milaboratories/pl-healthcheck': 1.0.2
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-common': 1.47.0
       '@milaboratories/ts-helpers': 1.8.4
       decompress: 4.2.1
       ssh2: 1.16.0
@@ -5778,14 +5818,14 @@ snapshots:
       yaml: 2.8.1
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.16.8':
+  '@milaboratories/pl-drivers@1.16.9':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/computable': 2.9.6
       '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-tree': 1.12.19
+      '@milaboratories/pl-client': 3.14.1
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/pl-tree': 1.13.0
       '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
@@ -5813,9 +5853,9 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-errors@1.4.29':
+  '@milaboratories/pl-errors@1.4.30':
     dependencies:
-      '@milaboratories/pl-client': 3.14.0
+      '@milaboratories/pl-client': 3.14.1
       '@milaboratories/ts-helpers': 1.8.4
       zod: 3.25.76
 
@@ -5831,27 +5871,28 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.65.9(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.66.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
+      '@milaboratories/columns-collection-driver': 0.2.0
       '@milaboratories/computable': 2.9.6
       '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pf-driver': 1.7.16(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-driver': 1.8.0(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.19(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-deployments': 3.0.10
-      '@milaboratories/pl-drivers': 1.16.8
-      '@milaboratories/pl-errors': 1.4.29
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.0)(@milaboratories/pl-model-middle-layer@1.30.12)
+      '@milaboratories/pl-client': 3.14.1
+      '@milaboratories/pl-deployments': 3.0.11
+      '@milaboratories/pl-drivers': 1.16.9
+      '@milaboratories/pl-errors': 1.4.30
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.14
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
-      '@milaboratories/pl-tree': 1.12.19
+      '@milaboratories/pl-model-backend': 1.4.15
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/pl-model-middle-layer': 1.30.12
+      '@milaboratories/pl-tree': 1.13.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.4
-      '@platforma-sdk/block-tools': 2.12.4(@types/node@24.5.2)
-      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/block-tools': 2.12.5(@types/node@24.5.2)
+      '@platforma-sdk/model': 1.80.0
       '@platforma-sdk/workflow-tengo': 6.7.1
       canonicalize: 2.1.0
       denque: 2.1.0
@@ -5871,9 +5912,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.14':
+  '@milaboratories/pl-model-backend@1.4.15':
     dependencies:
-      '@milaboratories/pl-client': 3.14.0
+      '@milaboratories/pl-client': 3.14.1
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -5882,13 +5923,6 @@ snapshots:
       '@milaboratories/pl-error-like': 1.12.5
       canonicalize: 2.1.0
       zod: 3.23.8
-
-  '@milaboratories/pl-model-common@1.45.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-error-like': 1.12.10
-      canonicalize: 2.1.0
-      zod: 3.25.76
 
   '@milaboratories/pl-model-common@1.46.2':
     dependencies:
@@ -5904,10 +5938,26 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
+  '@milaboratories/pl-model-common@1.47.0':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-error-like': 1.12.10
+      canonicalize: 2.1.0
+      es-toolkit: 1.41.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-middle-layer@1.30.11':
     dependencies:
       '@milaboratories/helpers': 1.14.3
       '@milaboratories/pl-model-common': 1.46.4
+      es-toolkit: 1.41.0
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.30.12':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-model-common': 1.47.0
       es-toolkit: 1.41.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -5920,11 +5970,11 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.12.19':
+  '@milaboratories/pl-tree@1.13.0':
     dependencies:
       '@milaboratories/computable': 2.9.6
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-errors': 1.4.29
+      '@milaboratories/pl-client': 3.14.1
+      '@milaboratories/pl-errors': 1.4.30
       '@milaboratories/ts-helpers': 1.8.4
       denque: 2.1.0
       utility-types: 3.11.0
@@ -5937,6 +5987,10 @@ snapshots:
   '@milaboratories/ptabler-expression-js@1.2.33':
     dependencies:
       '@platforma-open/milaboratories.software-ptabler.schema': 1.15.17
+
+  '@milaboratories/ptabler-expression-js@1.2.34':
+    dependencies:
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.18
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -6075,7 +6129,7 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.13(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.14(typescript@5.9.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.3
       '@platforma-sdk/model': 1.79.27
@@ -6109,10 +6163,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@milaboratories/uikit@2.15.14(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.15(typescript@5.9.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.3
-      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/model': 1.80.0
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -6388,15 +6442,15 @@ snapshots:
 
   '@platforma-open/milaboratories.mixcr-clonotyping-2.model@1.20.0':
     dependencies:
-      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/model': 1.80.0
       zod: 3.23.8
 
   '@platforma-open/milaboratories.mixcr-clonotyping-2.ui@1.19.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.3
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model': 1.20.0
-      '@platforma-sdk/model': 1.79.27
-      '@platforma-sdk/ui-vue': 1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@platforma-sdk/model': 1.80.0
+      '@platforma-sdk/ui-vue': 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@vueuse/core': 13.9.0(vue@3.5.25(typescript@5.9.3))
       ag-grid-enterprise: 34.1.2
       ag-grid-vue3: 34.1.2(vue@3.5.25(typescript@5.9.3))
@@ -6428,7 +6482,7 @@ snapshots:
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model': 1.20.0
       '@platforma-open/milaboratories.mixcr-clonotyping-2.ui': 1.19.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@platforma-open/milaboratories.mixcr-clonotyping-2.workflow': 3.17.1
-      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/model': 1.80.0
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - async-validator
@@ -6479,6 +6533,10 @@ snapshots:
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
     dependencies:
       '@milaboratories/pl-model-common': 1.46.4
+
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.18':
+    dependencies:
+      '@milaboratories/pl-model-common': 1.47.0
 
   '@platforma-open/milaboratories.software-ptabler@1.13.5': {}
 
@@ -6549,15 +6607,15 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.12.4(@types/node@24.5.2)':
+  '@platforma-sdk/block-tools@2.12.5(@types/node@24.5.2)':
     dependencies:
       '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.14
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/pl-model-backend': 1.4.15
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/pl-model-middle-layer': 1.30.12
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.4
       '@platforma-sdk/blocks-deps-updater': 2.2.0
@@ -6601,6 +6659,20 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
+  '@platforma-sdk/model@1.80.0':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-error-like': 1.12.10
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/pl-model-middle-layer': 1.30.12
+      '@milaboratories/ptabler-expression-js': 1.2.34
+      canonicalize: 2.1.0
+      es-toolkit: 1.41.0
+      fast-json-patch: 3.1.1
+      lru-cache: 11.2.2
+      utility-types: 3.11.0
+      zod: 3.25.76
+
   '@platforma-sdk/package-builder-lib@1.2.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
@@ -6614,22 +6686,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@4.0.16':
+  '@platforma-sdk/tengo-builder@4.0.17':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.4.14
+      '@milaboratories/pl-model-backend': 1.4.15
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.4
       commander: 15.0.0
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.80.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
     dependencies:
       '@milaboratories/computable': 2.9.6
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-middle-layer': 1.65.9(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
-      '@milaboratories/pl-tree': 1.12.19
-      '@platforma-sdk/model': 1.79.27
+      '@milaboratories/pl-client': 3.14.1
+      '@milaboratories/pl-middle-layer': 1.66.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-tree': 1.13.0
+      '@platforma-sdk/model': 1.80.0
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
       vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -6651,11 +6723,11 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/uikit': 2.15.13(typescript@5.9.3)
+      '@milaboratories/uikit': 2.15.14(typescript@5.9.3)
       '@platforma-sdk/model': 1.79.27
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
@@ -6687,12 +6759,13 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/ui-vue@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.80.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/uikit': 2.15.14(typescript@5.9.3)
-      '@platforma-sdk/model': 1.79.27
+      '@milaboratories/columns-collection-driver': 0.2.0
+      '@milaboratories/pf-spec-driver': 1.4.19(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.47.0
+      '@milaboratories/uikit': 2.15.15(typescript@5.9.3)
+      '@platforma-sdk/model': 1.80.0
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,16 +9,16 @@ catalog:
   "@milaboratories/ts-builder": 1.6.0
   "@milaboratories/ts-configs": 1.3.0
   "@milaboratories/build-configs": 2.0.0
-  "@milaboratories/pl-model-common": 1.47.0
-  "@platforma-sdk/workflow-tengo": 6.7.1
-  "@platforma-sdk/model": 1.80.0
-  "@platforma-sdk/ui-vue": 1.80.0
-  "@platforma-sdk/tengo-builder": 4.0.17
+  "@milaboratories/pl-model-common": 1.47.1
+  "@platforma-sdk/workflow-tengo": 6.7.2
+  "@platforma-sdk/model": 1.80.2
+  "@platforma-sdk/ui-vue": 1.80.2
+  "@platforma-sdk/tengo-builder": 4.0.18
   "@platforma-sdk/package-builder": 3.14.1
-  "@platforma-sdk/block-tools": 2.12.5
+  "@platforma-sdk/block-tools": 2.12.6
 
-  "@platforma-sdk/test": 1.80.0
-  "@milaboratories/helpers": 1.14.3
+  "@platforma-sdk/test": 1.80.2
+  "@milaboratories/helpers": 1.14.4
 
   "@platforma-open/milaboratories.runenv-python-3": ^1.7.7
   "@platforma-open/milaboratories.software-ptransform": ^1.6.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,12 +12,12 @@ catalog:
   "@milaboratories/pl-model-common": 1.47.1
   "@platforma-sdk/workflow-tengo": 6.7.2
   "@platforma-sdk/model": 1.80.2
-  "@platforma-sdk/ui-vue": 1.80.2
+  "@platforma-sdk/ui-vue": 1.80.4
   "@platforma-sdk/tengo-builder": 4.0.18
   "@platforma-sdk/package-builder": 3.14.1
   "@platforma-sdk/block-tools": 2.12.6
 
-  "@platforma-sdk/test": 1.80.2
+  "@platforma-sdk/test": 1.80.3
   "@milaboratories/helpers": 1.14.4
 
   "@platforma-open/milaboratories.runenv-python-3": ^1.7.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,15 +9,15 @@ catalog:
   "@milaboratories/ts-builder": 1.6.0
   "@milaboratories/ts-configs": 1.3.0
   "@milaboratories/build-configs": 2.0.0
-  "@milaboratories/pl-model-common": 1.45.0
+  "@milaboratories/pl-model-common": 1.47.0
   "@platforma-sdk/workflow-tengo": 6.7.1
-  "@platforma-sdk/model": 1.79.27
-  "@platforma-sdk/ui-vue": 1.79.34
-  "@platforma-sdk/tengo-builder": 4.0.16
+  "@platforma-sdk/model": 1.80.0
+  "@platforma-sdk/ui-vue": 1.80.0
+  "@platforma-sdk/tengo-builder": 4.0.17
   "@platforma-sdk/package-builder": 3.14.1
-  "@platforma-sdk/block-tools": 2.12.4
+  "@platforma-sdk/block-tools": 2.12.5
 
-  "@platforma-sdk/test": 1.79.34
+  "@platforma-sdk/test": 1.80.0
   "@milaboratories/helpers": 1.14.3
 
   "@platforma-open/milaboratories.runenv-python-3": ^1.7.7

--- a/ui/src/components/SettingsModal.vue
+++ b/ui/src/components/SettingsModal.vue
@@ -1,8 +1,16 @@
 <script setup lang="ts">
 import { PlDropdownRef, PlSlideModal } from "@platforma-sdk/ui-vue";
+import { computed } from "vue";
 import { useApp } from "../app";
 
 const app = useApp();
+
+// Dataset anchor options for the input dropdown — translate `getColumnOptions`
+// `{ id, label }` shape into `{ value, label }` accepted by `PlDropdownRef`'s
+// generic `ListOption<M>` slot.
+const inputAnchorOptions = computed(() =>
+  app.model.outputs.inputOptions?.map((o) => ({ value: o.id, label: o.label })),
+);
 </script>
 
 <template>
@@ -10,7 +18,7 @@ const app = useApp();
     <template #title>Settings</template>
     <PlDropdownRef
       v-model="app.model.data.inputAnchor"
-      :options="app.model.outputs.inputOptions"
+      :options="inputAnchorOptions"
       label="Select dataset"
       clearable
     />

--- a/ui/src/components/SettingsModal.vue
+++ b/ui/src/components/SettingsModal.vue
@@ -8,8 +8,8 @@ const app = useApp();
 // Dataset anchor options for the input dropdown — translate `getColumnOptions`
 // `{ id, label }` shape into `{ value, label }` accepted by `PlDropdownRef`'s
 // generic `ListOption<M>` slot.
-const inputAnchorOptions = computed(() =>
-  app.model.outputs.inputOptions?.map((o) => ({ value: o.id, label: o.label })),
+const inputAnchorOptions = computed(
+  () => app.model.outputs.inputOptions?.map((o) => ({ value: o.id, label: o.label })) ?? [],
 );
 </script>
 

--- a/ui/src/composition/useColumnSuggestion.ts
+++ b/ui/src/composition/useColumnSuggestion.ts
@@ -1,5 +1,6 @@
-import type { ListOptionBase, SUniversalPColumnId } from "@milaboratories/pl-model-common";
+import type { ListOptionBase, PObjectId } from "@milaboratories/pl-model-common";
 import { getUniqueSourceValuesWithLabels } from "@platforma-sdk/model";
+import type { PlAdvancedFilterColumnId } from "@platforma-sdk/ui-vue";
 
 import { useApp } from "../app";
 
@@ -7,7 +8,7 @@ export function useColumnSuggestion() {
   const app = useApp();
 
   const suggest = async (params: {
-    columnId: string;
+    columnId: PlAdvancedFilterColumnId;
     axisIdx?: number;
     searchStr: string;
     searchType: "value" | "label";
@@ -16,7 +17,9 @@ export function useColumnSuggestion() {
     if (handle == null) return [];
 
     const response = await getUniqueSourceValuesWithLabels(handle, {
-      columnId: params.columnId as SUniversalPColumnId,
+      // `getUniqueSourceValuesWithLabels` still types `columnId` as PObjectId,
+      // but the host accepts any ColumnUniversalId (wrapped recipes included).
+      columnId: params.columnId as PObjectId,
       axisIdx: params.axisIdx,
       limit: 300,
       searchQuery: params.searchType === "label" ? params.searchStr : undefined,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the clonotype-browser block to the new Platforma SDK column-access API (`@platforma-sdk/model` 1.80.2) and bumps related SDK packages. The central change is replacing `PlRef`-based column lookup with `ColumnUniversalId`-keyed helpers (`Column()`, `ColumnsCollection`, `ColumnRecipe`), including a data-model migration (`Ver_2026_05_28`) that converts persisted `PlRef` anchors to `ColumnUniversalId` strings.

- Data model gains a `Ver_2026_05_28` migration that converts `inputAnchor` from `PlRef` to `ColumnUniversalId` via a three-step chain: `StoredV1` → `StoredV2` → `BlockData`.
- `findOverlapMatches`, `overlapTable`, `statsTable`, and `sampleTableSheets` are rewritten to use `ColumnsCollection`/`ColumnRecipe` throughout, removing `splitByPartition`, `toTableColumnVariant`, and `OutputColumnProvider`.
- Visibility rules for the overlap table switch from function predicates to annotation-based matchers (semantically equivalent, confirmed by `isAbundanceColumn` checking `Annotation.IsAbundance`).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the migration chain and new column-access API are correctly wired, and no new defects were found beyond those already tracked in prior review threads.

The three-step migration chain correctly converts inputAnchor from PlRef to ColumnUniversalId, and the universalIdToPlRef round-trip in enriches() is well-documented and only reachable for result-pool columns. Visibility rules are semantically equivalent to the old function predicates. No new regressions or logic errors were introduced beyond previously flagged concerns.

model/src/index.ts — the overlapTable and statsTable outputs both call expandByPartition and check its return; behaviour when splitInputs is empty remains a known open question tracked in previous threads.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/dataModel.ts | Adds Ver_2026_05_28 migration converting inputAnchor from PlRef to ColumnUniversalId; introduces named StoredV1/StoredV2 intermediate types for a clearer migration chain. |
| model/src/index.ts | Full rewrite of column-access logic to new SDK API (ColumnsCollection, Column, ColumnRecipe); overlapTable can return undefined when splitInputs is empty (previously flagged). universalIdToPlRef round-trip for enriches() is well-documented. |
| model/src/types.ts | inputAnchor type changed from PlRef to ColumnUniversalId in BlockArgs and BlockData; LegacyBlockArgs retains PlRef for migration purposes. |
| ui/src/components/SettingsModal.vue | Updated to map new deriveColumnOptions shape ({id, label}) to PlDropdownRef's generic ListOption<M> format; v-model now stores ColumnUniversalId strings. |
| ui/src/composition/useColumnSuggestion.ts | Adds as PObjectId cast for getUniqueSourceValuesWithLabels; comment explains the host accepts ColumnUniversalId despite the stale SDK typing. |
| .changeset/pink-wings-dream.md | Patch changeset for the SDK migration across model, ui, and block packages. |
| pnpm-workspace.yaml | SDK version bumps across all Platforma packages (model 1.80.2, ui-vue 1.80.2, block-tools 2.12.6, etc.). |

</details>

<sub>Reviews (2): Last reviewed commit: ["Upgrade to released SDK with brand fix: ..."](https://github.com/platforma-open/clonotype-browser/commit/cfa0d023ab66af81dae1570a1efcd5a38b68efea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37601472)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->