### PR TITLE
chore: refresh SDK dependencies and block structure

### DIFF
--- a/.changeset/upgrade-sdk.md
+++ b/.changeset/upgrade-sdk.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.clonotype-browser-3": patch
+"@platforma-open/milaboratories.clonotype-browser-3.model": patch
+"@platforma-open/milaboratories.clonotype-browser-3.ui": patch
+"@platforma-open/milaboratories.clonotype-browser-3.workflow": patch
+---
+
+SDK Update

--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
     "oxfmt": "*",
     "oxlint": "*"
   },
-  "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab"
+  "packageManager": "pnpm@9.12.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^1.2.3
       version: 1.2.3
     '@platforma-sdk/block-tools':
-      specifier: 2.12.6
-      version: 2.12.6
+      specifier: 2.12.7
+      version: 2.12.7
     '@platforma-sdk/model':
       specifier: 1.80.2
       version: 1.80.2
@@ -37,8 +37,8 @@ catalogs:
       specifier: 4.0.18
       version: 4.0.18
     '@platforma-sdk/test':
-      specifier: 1.80.3
-      version: 1.80.3
+      specifier: 1.80.5
+      version: 1.80.5
     '@platforma-sdk/ui-vue':
       specifier: 1.80.4
       version: 1.80.4
@@ -98,7 +98,7 @@ importers:
         version: 1.6.0(@types/node@24.5.2)(rollup@4.46.2)(sass-embedded@1.89.2)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.5.2)
+        version: 2.12.7(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -128,7 +128,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.5.2)
+        version: 2.12.7(@types/node@24.5.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
         version: 1.80.2
@@ -168,7 +168,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.5.2)
+        version: 2.12.7(@types/node@24.5.2)
 
   test:
     dependencies:
@@ -205,7 +205,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.80.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
@@ -279,7 +279,7 @@ importers:
         version: 4.0.18
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
+        version: 1.80.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -978,8 +978,8 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.66.3':
-    resolution: {integrity: sha512-6nkpOyjWXPsHxDpOOFDDpicCSLP4XwgdfN3xVKtbkMUrIPUEpplmje3xe1JA3fR2I22zBBpyEj2r6pI/Jg9Ajg==}
+  '@milaboratories/pl-middle-layer@1.66.4':
+    resolution: {integrity: sha512-rFyxoWpFNjA5FPU6A5Usf0FyDx+XzFSsDqsPRf3NVuxrk6No6cNGZVUerdpXZJ6qCEsJwdgMBRECyBI5MV5bRw==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-model-backend@1.4.16':
@@ -1453,8 +1453,8 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.12.6':
-    resolution: {integrity: sha512-MtsYTCNhCCA9drSihSh5uXUY2/qCNai/ekOX2pw2gtzjHPXPqnin1Wzri0z/2N1wOShXodRItBUglALNJFWUsQ==}
+  '@platforma-sdk/block-tools@2.12.7':
+    resolution: {integrity: sha512-a13K0hcXYf+sgx+07QFjIu2uTeTH5lhHHI1o563kvs9Z5vssU9jn7HFgXgSe6TMjDntERJcGHiGm8nUd4t3FiA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1475,8 +1475,8 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.80.3':
-    resolution: {integrity: sha512-q0hETSlBMsEM53/6Xs29lAar+XJrrwZS6mmau1LSfDfy9OHdGfZ7YEpYDyRzfITlKOV1Z0WqLC0s21gtLQAMIA==}
+  '@platforma-sdk/test@1.80.5':
+    resolution: {integrity: sha512-z3tBrNWIg0+OfUOKpiZWCFflSW17J/Tv7DRWK99IzaaS0+MrIhC6oEFJGXnDlbynhnhSp3E+a4HiwEe+SG/rCg==}
 
   '@platforma-sdk/ui-vue@1.80.4':
     resolution: {integrity: sha512-DQbuO3fAJ3CQxiJkXMiNuo1Qyd/C92AatOZX90ElLFohXiP3XbJNXNjrIxypzsUc850dKkqbPjKd0JTzD12E9w==}
@@ -5835,7 +5835,7 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.66.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.66.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
       '@milaboratories/columns-collection-driver': 0.2.1
       '@milaboratories/computable': 2.9.7
@@ -5855,7 +5855,7 @@ snapshots:
       '@milaboratories/pl-tree': 1.13.1
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.5
-      '@platforma-sdk/block-tools': 2.12.6(@types/node@24.5.2)
+      '@platforma-sdk/block-tools': 2.12.7(@types/node@24.5.2)
       '@platforma-sdk/model': 1.80.2
       '@platforma-sdk/workflow-tengo': 6.7.2
       canonicalize: 2.1.0
@@ -6514,7 +6514,7 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.12.6(@types/node@24.5.2)':
+  '@platforma-sdk/block-tools@2.12.7(@types/node@24.5.2)':
     dependencies:
       '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
@@ -6589,11 +6589,11 @@ snapshots:
       commander: 15.0.0
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.80.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.80.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.2)(yaml@2.8.1))':
     dependencies:
       '@milaboratories/computable': 2.9.7
       '@milaboratories/pl-client': 3.14.2
-      '@milaboratories/pl-middle-layer': 1.66.3(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-middle-layer': 1.66.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
       '@milaboratories/pl-tree': 1.13.1
       '@platforma-sdk/model': 1.80.2
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,9 +15,9 @@ catalog:
   "@platforma-sdk/ui-vue": 1.80.4
   "@platforma-sdk/tengo-builder": 4.0.18
   "@platforma-sdk/package-builder": 3.14.1
-  "@platforma-sdk/block-tools": 2.12.6
+  "@platforma-sdk/block-tools": 2.12.7
 
-  "@platforma-sdk/test": 1.80.3
+  "@platforma-sdk/test": 1.80.5
   "@milaboratories/helpers": 1.14.4
 
   "@platforma-open/milaboratories.runenv-python-3": ^1.7.7


### PR DESCRIPTION
Refresh SDK dependencies and block structure via `pnpm upgrade-sdk`.

This runs:
- `block-tools structure refresh --update-deps-only` + `pnpm i`
- `block-tools structure refresh` + `pnpm i`
- `pnpm fmt`

Includes a patch changeset ("SDK Update").

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades SDK dependencies via `pnpm upgrade-sdk`, bumping `@platforma-sdk/block-tools` (2.12.6→2.12.7), `@platforma-sdk/test` (1.80.3→1.80.5), and the transitive `@milaboratories/pl-middle-layer` (1.66.3→1.66.4). A patch changeset marks all four block packages for release, but the `package.json` `packageManager` field was unintentionally overwritten as a side-effect.

- **`@platforma-sdk/block-tools` 2.12.6→2.12.7** and **`@platforma-sdk/test` 1.80.3→1.80.5**: straightforward patch/minor bumps reflected consistently across `pnpm-workspace.yaml` and `pnpm-lock.yaml`.
- **`packageManager` field regressed**: changed from `pnpm@9.14.4+sha512.c8180b3...` to `pnpm@9.12.0` — the version was rolled back two minor releases and the sha512 integrity hash was stripped, weakening supply-chain verification for anyone using corepack.

**Touched Terms:**

| Term | Definition | Change in this PR |
|------|-----------|-------------------|
| `packageManager` | `package.json` field consumed by corepack to pin the exact package manager binary (version + sha512 hash) for a repo | Downgraded from `pnpm@9.14.4+sha512.c8180b3…` to `pnpm@9.12.0`; integrity hash removed |
| `@platforma-sdk/block-tools` | CLI tool used to scaffold and refresh Platforma block structure | Bumped from `2.12.6` to `2.12.7` in catalog and lockfile |
| `@platforma-sdk/test` | SDK testing utilities for Platforma blocks (wraps vitest + pl-client) | Bumped from `1.80.3` to `1.80.5` (skips 1.80.4) in catalog and lockfile |
| `@milaboratories/pl-middle-layer` | Middleware layer that connects the Platforma client to the backend; transitive dependency of `@platforma-sdk/test` | Updated from `1.66.3` to `1.66.4` in lockfile snapshots |
| `catalog` | pnpm workspace catalog — a shared version-pin table in `pnpm-workspace.yaml` consumed by all workspace packages via `specifier: 'catalog:'` | Two catalog entries (`block-tools`, `test`) bumped to reflect new SDK versions |

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The SDK bumps are clean and consistent across all files, but the packageManager field was inadvertently downgraded and its integrity hash stripped.

The dependency updates are well-formed and internally consistent. The one real issue is in package.json: the block-tools refresh command appears to have overwritten the packageManager field, rolling it back from pnpm 9.14.4 (with a corepack-verifiable sha512 hash) to pnpm 9.12.0 without a hash. This means any engineer or CI pipeline using corepack will silently switch to an older pnpm binary and lose cryptographic verification of it. The SDK changes themselves look safe to ship once the packageManager regression is resolved.

package.json — the packageManager field needs to be restored to pnpm@9.14.4 with its original sha512 hash (or updated to the intended newer version with a fresh hash).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/upgrade-sdk.md | Standard patch changeset file listing all four block sub-packages; no issues. |
| package.json | packageManager field unintentionally downgraded from pnpm@9.14.4 (with sha512 hash) to pnpm@9.12.0 (hash stripped), weakening supply-chain verification and rolling back the package manager version. |
| pnpm-workspace.yaml | Catalog bumps block-tools 2.12.6→2.12.7 and test 1.80.3→1.80.5; consistent with lockfile changes. |
| pnpm-lock.yaml | Generated lockfile; updates block-tools, test, and the transitive pl-middle-layer 1.66.3→1.66.4 consistently across all importers. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pnpm upgrade-sdk\n(block-tools CLI)"] --> B["block-tools structure refresh\n--update-deps-only"]
    B --> C["pnpm i"]
    A --> D["block-tools structure refresh"]
    D --> E["pnpm i"]
    A --> F["pnpm fmt"]

    C --> G["pnpm-workspace.yaml\ncatalog updated"]
    E --> G
    G --> H["@platforma-sdk/block-tools\n2.12.6 → 2.12.7"]
    G --> I["@platforma-sdk/test\n1.80.3 → 1.80.5"]

    H --> J["pnpm-lock.yaml\nlockfile regenerated"]
    I --> J
    J --> K["@milaboratories/pl-middle-layer\n1.66.3 → 1.66.4\n(transitive)"]

    B --> L["package.json modified\n⚠️ packageManager\npnpm@9.14.4+sha512 → pnpm@9.12.0\n(downgrade + hash removed)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["pnpm upgrade-sdk\n(block-tools CLI)"] --> B["block-tools structure refresh\n--update-deps-only"]
    B --> C["pnpm i"]
    A --> D["block-tools structure refresh"]
    D --> E["pnpm i"]
    A --> F["pnpm fmt"]

    C --> G["pnpm-workspace.yaml\ncatalog updated"]
    E --> G
    G --> H["@platforma-sdk/block-tools\n2.12.6 → 2.12.7"]
    G --> I["@platforma-sdk/test\n1.80.3 → 1.80.5"]

    H --> J["pnpm-lock.yaml\nlockfile regenerated"]
    I --> J
    J --> K["@milaboratories/pl-middle-layer\n1.66.3 → 1.66.4\n(transitive)"]

    B --> L["package.json modified\n⚠️ packageManager\npnpm@9.14.4+sha512 → pnpm@9.12.0\n(downgrade + hash removed)"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackage.json%3A35%0A**pnpm%20version%20downgraded%20and%20integrity%20hash%20removed**%0A%0AThe%20%60packageManager%60%20field%20changed%20from%20%60pnpm%409.14.4%2Bsha512.c8180b3...%60%20to%20%60pnpm%409.12.0%60.%20This%20is%20a%20two-part%20regression%3A%20%281%29%20the%20version%20is%20rolled%20back%20by%20two%20minor%20releases%2C%20which%20will%20cause%20any%20developer%20or%20CI%20runner%20relying%20on%20corepack%20to%20switch%20to%20an%20older%20binary%3B%20%282%29%20the%20sha512%20hash%20is%20dropped%20entirely%2C%20removing%20the%20cryptographic%20guarantee%20that%20corepack%20downloads%20the%20exact%20trusted%20binary.%20Without%20the%20hash%2C%20corepack%20will%20accept%20any%20pnpm%20binary%20that%20self-reports%20as%209.12.0.%20Was%20this%20change%20intentional%2C%20or%20did%20%60block-tools%20structure%20refresh%60%20inadvertently%20overwrite%20the%20field%3F%0A%0A&repo=platforma-open%2Fclonotype-browser&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package.json:35
**pnpm version downgraded and integrity hash removed**

The `packageManager` field changed from `pnpm@9.14.4+sha512.c8180b3...` to `pnpm@9.12.0`. This is a two-part regression: (1) the version is rolled back by two minor releases, which will cause any developer or CI runner relying on corepack to switch to an older binary; (2) the sha512 hash is dropped entirely, removing the cryptographic guarantee that corepack downloads the exact trusted binary. Without the hash, corepack will accept any pnpm binary that self-reports as 9.12.0. Was this change intentional, or did `block-tools structure refresh` inadvertently overwrite the field?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: refresh SDK dependencies and bloc..."](https://github.com/platforma-open/clonotype-browser/commit/3055f6d21d4be88dbdc699a228842baf10ca4f96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44502394)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->